### PR TITLE
deps: drop cap-std dep; use cap_std_ext re-export

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,6 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "camino",
- "cap-std",
  "cap-std-ext",
  "chrono",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,6 @@ publish = false
 [dependencies]
 anyhow = "1"
 camino = { version = "1", features = ["serde1"] }
-cap-std = { version = "3", default-features = false, features = ["fs_utf8"] }
 cap-std-ext = { version = "4", default-features = false, features = ["fs_utf8"] }
 chrono = "0.4"
 clap = { version = "4", default-features = false, features = ["derive", "std", "help", "usage", "error-context", "env"] }

--- a/src/cmd_build.rs
+++ b/src/cmd_build.rs
@@ -2,8 +2,8 @@ use std::collections::HashMap;
 
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
-use cap_std::ambient_authority;
-use cap_std::fs::Dir;
+use cap_std_ext::cap_std::ambient_authority;
+use cap_std_ext::cap_std::fs::Dir;
 use clap::Parser;
 use ocidir::oci_spec::image as oci_image;
 use serde::Deserialize;
@@ -400,9 +400,7 @@ mod tests {
         let parsed = parse_config(CONFIG_FIXTURE).unwrap();
         let image_config = build_image_config(&args, parsed.config, 1, "amd64").unwrap();
 
-        let rootfs =
-            cap_std::fs::Dir::open_ambient_dir(rootfs_dir.path(), cap_std::ambient_authority())
-                .unwrap();
+        let rootfs = Dir::open_ambient_dir(rootfs_dir.path(), ambient_authority()).unwrap();
 
         // create a single empty component for testing
         let components = vec![(
@@ -428,9 +426,7 @@ mod tests {
         let mut archive = tar::Archive::new(output.as_slice());
         archive.unpack(oci_tempdir.path()).unwrap();
 
-        let oci_dir_cap =
-            cap_std::fs::Dir::open_ambient_dir(oci_tempdir.path(), cap_std::ambient_authority())
-                .unwrap();
+        let oci_dir_cap = Dir::open_ambient_dir(oci_tempdir.path(), ambient_authority()).unwrap();
         let oci_dir = ocidir::OciDir::open(oci_dir_cap).unwrap();
 
         // get the image manifest (we don't set a tag, so use the index)

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -8,7 +8,7 @@ pub const UNCLAIMED_COMPONENT: &str = "chunkah/unclaimed";
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use cap_std::fs::Dir;
+use cap_std_ext::cap_std::fs::{Dir, FileType as CapFileType, Metadata, MetadataExt};
 
 /// Seconds per day.
 pub const SECS_PER_DAY: u64 = 60 * 60 * 24;
@@ -69,7 +69,7 @@ impl FileType {
     /// Try to convert from cap_std file type.
     ///
     /// Returns `None` for unsupported types (sockets, FIFOs, block/char devices).
-    pub fn from_cap_std(file_type: &cap_std::fs::FileType) -> Option<Self> {
+    pub fn from_cap_std(file_type: &CapFileType) -> Option<Self> {
         if file_type.is_dir() {
             Some(FileType::Directory)
         } else if file_type.is_file() {
@@ -85,12 +85,10 @@ impl FileType {
 impl FileInfo {
     /// Create FileInfo from metadata and xattrs.
     pub fn from_metadata(
-        metadata: &cap_std::fs::Metadata,
+        metadata: &Metadata,
         file_type: FileType,
         xattrs: Vec<(String, Vec<u8>)>,
     ) -> Self {
-        use cap_std::fs::MetadataExt;
-
         Self {
             file_type,
             mode: metadata.mode(),
@@ -242,8 +240,7 @@ trait ComponentsRepo {
 #[cfg(test)]
 mod tests {
     use camino::Utf8Path;
-    use cap_std::ambient_authority;
-    use cap_std::fs::Dir;
+    use cap_std_ext::cap_std::ambient_authority;
     use cap_std_ext::dirext::CapStdExtDirExt;
 
     use super::*;

--- a/src/components/rpm.rs
+++ b/src/components/rpm.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use cap_std::fs::Dir;
+use cap_std_ext::cap_std::fs::Dir;
 use indexmap::IndexMap;
 use rpm_qa::FileInfo;
 
@@ -219,6 +219,7 @@ fn file_info_to_file_type(fi: &FileInfo) -> Option<FileType> {
 #[cfg(test)]
 mod tests {
     use camino::Utf8Path;
+    use cap_std_ext::cap_std::ambient_authority;
 
     use super::*;
 
@@ -356,8 +357,7 @@ mod tests {
             std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/rpmdb.sqlite");
         std::fs::copy(&fixture_path, rpmdb_dir.join("rpmdb.sqlite")).unwrap();
 
-        let rootfs =
-            cap_std::fs::Dir::open_ambient_dir(tmp.path(), cap_std::ambient_authority()).unwrap();
+        let rootfs = Dir::open_ambient_dir(tmp.path(), ambient_authority()).unwrap();
 
         let repo = RpmRepo::load(&rootfs).unwrap().unwrap();
 

--- a/src/components/xattr.rs
+++ b/src/components/xattr.rs
@@ -133,8 +133,8 @@ impl ComponentsRepo for XattrRepo {
 
 #[cfg(test)]
 mod tests {
-    use cap_std::ambient_authority;
-    use cap_std::fs::Dir;
+    use cap_std_ext::cap_std::ambient_authority;
+    use cap_std_ext::cap_std::fs::Dir;
     use cap_std_ext::dirext::CapStdExtDirExt;
 
     use super::*;

--- a/src/ocibuilder.rs
+++ b/src/ocibuilder.rs
@@ -2,7 +2,7 @@ use std::collections::HashMap;
 use std::io::Write;
 
 use anyhow::{Context, Result};
-use cap_std::fs::Dir;
+use cap_std_ext::cap_std::fs::Dir;
 use ocidir::oci_spec::image as oci_image;
 
 use crate::components::Component;
@@ -36,7 +36,7 @@ pub struct Builder {
 impl Builder {
     /// Create a new Builder with required parameters.
     pub fn new(rootfs: &Dir, components: Vec<(String, Component)>) -> Result<Self> {
-        let oci_dir = cap_std_ext::cap_tempfile::tempdir(cap_std::ambient_authority())
+        let oci_dir = cap_std_ext::cap_tempfile::tempdir(cap_std_ext::cap_std::ambient_authority())
             .context("creating temp directory")?;
 
         Ok(Self {
@@ -189,8 +189,8 @@ impl Builder {
 mod tests {
     use super::*;
     use camino::Utf8PathBuf;
-    use cap_std::ambient_authority;
-    use cap_std::fs::PermissionsExt;
+    use cap_std_ext::cap_std::ambient_authority;
+    use cap_std_ext::cap_std::fs::PermissionsExt;
     use cap_std_ext::dirext::CapStdExtDirExt;
     use maplit::btreeset;
     use std::collections::BTreeSet;
@@ -403,7 +403,10 @@ mod tests {
 
                 rootfs.create_dir("mydir").unwrap();
                 rootfs
-                    .set_permissions("mydir", cap_std::fs::Permissions::from_mode(0o777))
+                    .set_permissions(
+                        "mydir",
+                        cap_std_ext::cap_std::fs::Permissions::from_mode(0o777),
+                    )
                     .unwrap();
 
                 rootfs.write("xattr_file", "xattr content").unwrap();

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -4,7 +4,7 @@ use std::path::Path;
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
-use cap_std::fs::Dir;
+use cap_std_ext::cap_std::fs::Dir;
 use cap_std_ext::dirext::{CapStdExtDirExt, WalkConfiguration};
 
 use crate::components::{FileInfo, FileMap, FileType};
@@ -215,7 +215,7 @@ fn check_prune(path: &Utf8Path, prune_paths: &[PrunePath]) -> PruneAction {
 #[cfg(test)]
 mod tests {
     use camino::Utf8Path;
-    use cap_std::ambient_authority;
+    use cap_std_ext::cap_std::ambient_authority;
 
     use super::*;
     use crate::components::FileType;

--- a/src/tar.rs
+++ b/src/tar.rs
@@ -3,6 +3,7 @@ use std::io::Write;
 
 use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
+use cap_std_ext::cap_std::fs::Dir;
 use ocidir::oci_spec::image as oci_image;
 use ocidir::{BlobWriter, WriteComplete};
 
@@ -101,7 +102,7 @@ pub fn create_layer(
 /// of the input BTreeMap for efficiency.
 pub fn write_files_to_tar<W: Write>(
     tar_builder: &mut tar::Builder<W>,
-    rootfs: &cap_std::fs::Dir,
+    rootfs: &Dir,
     files: &FileMap,
     mtime_clamp: u64,
 ) -> Result<()> {
@@ -179,7 +180,7 @@ pub fn write_files_to_tar<W: Write>(
 /// Write the OCI directory as a tar archive to a writer.
 // XXX: Consider upstreaming this to ocidir-rs.
 pub fn write_oci_archive<W: Write>(
-    oci_dir: &cap_std::fs::Dir,
+    oci_dir: &Dir,
     writer: W,
     compression: ArchiveCompression,
 ) -> Result<()> {
@@ -294,7 +295,7 @@ fn write_hardlink_entry<W: Write>(
 /// Write a regular file entry to the tar archive.
 fn write_file_entry<W: Write>(
     tar_builder: &mut tar::Builder<W>,
-    rootfs: &cap_std::fs::Dir,
+    rootfs: &Dir,
     path: &Utf8Path,
     mtime_clamp: u64,
     file_info: &FileInfo,
@@ -322,7 +323,7 @@ fn write_file_entry<W: Write>(
 /// Write a symlink entry to the tar archive.
 fn write_symlink_entry<W: Write>(
     tar_builder: &mut tar::Builder<W>,
-    rootfs: &cap_std::fs::Dir,
+    rootfs: &Dir,
     path: &Utf8Path,
     mtime_clamp: u64,
     file_info: &FileInfo,
@@ -347,7 +348,7 @@ fn write_symlink_entry<W: Write>(
     Ok(())
 }
 
-fn write_oci_archive_to<W: Write>(oci_dir: &cap_std::fs::Dir, writer: W) -> Result<()> {
+fn write_oci_archive_to<W: Write>(oci_dir: &Dir, writer: W) -> Result<()> {
     use cap_std_ext::dirext::CapStdExtDirExt;
     use std::ops::ControlFlow;
 
@@ -407,8 +408,8 @@ fn write_oci_archive_to<W: Write>(oci_dir: &cap_std::fs::Dir, writer: W) -> Resu
 #[cfg(test)]
 mod tests {
     use super::*;
-    use cap_std::ambient_authority;
-    use cap_std::fs::Dir;
+    use cap_std_ext::cap_std::ambient_authority;
+
     use cap_std_ext::dirext::CapStdExtDirExt;
 
     /// Helper to create a rootfs in a tempdir, run setup, write files to tar, and return raw bytes.


### PR DESCRIPTION
Remove the direct cap-std v3 dependency and instead use the cap_std re-export from cap-std-ext v4. That way we guarantee it's always deduped and also avoid having to maintain that dep separately.

Assisted-by: Claude Opus 4.5