### PR TITLE
rpm: canonicalize RPM paths to match filesystem scan

### DIFF
--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -119,7 +119,7 @@ impl ComponentsRepos {
             repos.push(Box::new(repo));
         }
 
-        if let Some(repo) = rpm::RpmRepo::load(rootfs).context("loading rpmdb")? {
+        if let Some(repo) = rpm::RpmRepo::load(rootfs, files).context("loading rpmdb")? {
             repos.push(Box::new(repo));
         }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -35,14 +35,14 @@ assert_has_components() {
     done
 }
 
-# Assert that an image has at least the expected number of layers.
-assert_min_layers() {
+# Assert that an image has exactly the expected number of layers.
+assert_layer_count() {
     local image="${1}"; shift
-    local min_count="${1}"; shift
+    local expected="${1}"; shift
     local count
     count=$(skopeo inspect "containers-storage:${image}" | jq '.LayersData | length')
-    if [[ ${count} -lt ${min_count} ]]; then
-        echo "ERROR: Expected at least ${min_count} layers, got ${count} in ${image}"
+    if [[ ${count} -ne ${expected} ]]; then
+        echo "ERROR: Expected ${expected} layers, got ${count} in ${image}"
         exit 1
     fi
 }

--- a/tests/e2e/test-buildtime-options.sh
+++ b/tests/e2e/test-buildtime-options.sh
@@ -46,3 +46,6 @@ assert_path_not_exists "${CHUNKED_IMAGE}" /prune-me
 # verify --prune /prune-children/ kept the directory but removed its contents
 assert_path_exists "${CHUNKED_IMAGE}" /prune-children
 assert_path_not_exists "${CHUNKED_IMAGE}" /prune-children/nested
+
+# verify we got exactly 64 layers (the default)
+assert_layer_count "${CHUNKED_IMAGE}" 64

--- a/tests/e2e/test-buildtime.sh
+++ b/tests/e2e/test-buildtime.sh
@@ -39,8 +39,8 @@ podman run --rm "${CHUNKED_IMAGE}" jq --version
 # check for expected components
 assert_has_components "${CHUNKED_IMAGE}" "rpm/filesystem" "rpm/setup" "rpm/glibc" "rpm/jq"
 
-# sanity-check we got at least 16 layers
-assert_min_layers "${CHUNKED_IMAGE}" 16
+# verify we got exactly 64 layers (the default)
+assert_layer_count "${CHUNKED_IMAGE}" 64
 
 # verify that security.capability xattrs are preserved
 caps=$(podman run --rm "${CHUNKED_IMAGE}" getcap /usr/bin/test-caps)

--- a/tests/e2e/test-existing-build.sh
+++ b/tests/e2e/test-existing-build.sh
@@ -30,5 +30,5 @@ podman run --rm "${CHUNKED_IMAGE}" cat /etc/os-release | grep Fedora
 # check for expected components
 assert_has_components "${CHUNKED_IMAGE}" "rpm/filesystem" "rpm/setup" "rpm/glibc"
 
-# sanity-check we got at least 16 layers
-assert_min_layers "${CHUNKED_IMAGE}" 16
+# verify we got exactly 64 layers (the default)
+assert_layer_count "${CHUNKED_IMAGE}" 64

--- a/tests/e2e/test-existing-run.sh
+++ b/tests/e2e/test-existing-run.sh
@@ -34,5 +34,5 @@ podman run --rm "${CHUNKED_IMAGE}" cat /etc/os-release | grep Fedora
 # check for expected components
 assert_has_components "${CHUNKED_IMAGE}" "rpm/filesystem" "rpm/setup" "rpm/glibc"
 
-# sanity-check we got at least 16 layers
-assert_min_layers "${CHUNKED_IMAGE}" 16
+# verify we got exactly 64 layers (the default)
+assert_layer_count "${CHUNKED_IMAGE}" 64

--- a/tests/e2e/test-fcos.sh
+++ b/tests/e2e/test-fcos.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+# Test splitting a Fedora CoreOS image.
+set -xeuo pipefail
+shopt -s inherit_errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=SCRIPTDIR/lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+TARGET_IMAGE="quay.io/fedora/fedora-coreos:stable"
+CHUNKED_IMAGE="localhost/fcos-chunked:test"
+
+cleanup() {
+    cleanup_images "${CHUNKED_IMAGE}"
+}
+trap cleanup EXIT
+
+# build split image using Containerfile.splitter API
+# notice here we --prune /sysroot/
+podman pull "${TARGET_IMAGE}"
+config_str=$(podman inspect "${TARGET_IMAGE}")
+buildah_build \
+    --from "${TARGET_IMAGE}" --build-arg CHUNKAH="${CHUNKAH_IMG:?}" \
+    --build-arg CHUNKAH_CONFIG_STR="${config_str}" \
+    --build-arg "CHUNKAH_ARGS=--prune /sysroot/ --max-layers 96" \
+    -t "${CHUNKED_IMAGE}" "${REPO_ROOT}/Containerfile.splitter"
+
+# sanity-check it
+podman run --rm "${CHUNKED_IMAGE}" cat /etc/os-release | grep CoreOS
+
+# check for expected FCOS components
+assert_has_components "${CHUNKED_IMAGE}" "rpm/kernel" "rpm/systemd" "rpm/ignition" "rpm/podman"
+
+# verify we got exactly 96 layers
+assert_layer_count "${CHUNKED_IMAGE}" 96
+
+# verify unclaimed layer is under 300MB (314572800 bytes)
+# XXX: we're working towards reworking unclaimed logic which should allow us to lower the threshold here
+unclaimed_size=$(skopeo inspect "containers-storage:${CHUNKED_IMAGE}" | \
+    jq '.LayersData[] | select(.Annotations["org.chunkah.component"] | contains("chunkah/unclaimed")) | .Size')
+[[ -n "${unclaimed_size}" ]]
+[[ ${unclaimed_size} -le 314572800 ]]
+
+# verify chunked image is not larger than original + 1%
+# (catches possible e.g. bad hardlink handling)
+size_original=$(podman image inspect "${TARGET_IMAGE}" | jq '.[0].Size')
+size_chunked=$(podman image inspect "${CHUNKED_IMAGE}" | jq '.[0].Size')
+max_size=$((size_original * 101 / 100))
+[[ ${size_chunked} -le ${max_size} ]]
+
+# run bootc lint
+podman run --rm "${CHUNKED_IMAGE}" bootc container lint


### PR DESCRIPTION
RPM database stores paths as they were at package build time, which may use compat symlinks (e.g., /lib/modules/... instead of /usr/lib/modules/...). This caused ~316 MB of kernel content to go to "unclaimed" instead of being claimed by rpm/kernel-* packages.

Add path canonicalization to RpmRepo::load() that resolves symlinks in directory components only before building the path-to-component mapping. The final component is intentionally not resolved, so that if a file that is supposed to be a file/directory according to the rpmdb turns out to be a symlink, the RPM does not claim it.

Assisted-by: Claude Opus 4.5