### PR TITLE
components: add bigfiles repo to claim large unclaimed files

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,8 @@ just clippy             # Run clippy linter
 just fmt                # Check code formatting
 just markdownlint       # Lint markdown files
 just checkall           # Run all checks (shellcheck, check, fmt, clippy, markdownlint)
-just test               # Run end-to-end tests (requires built container image)
+just test               # Run all end-to-end tests (requires built container image)
+just test fcos          # Run only the FCOS e2e test
 just buildimg           # Build chunkah container image
 just buildimg nochunk   # Build chunkah container image without chunking (faster)
 ```

--- a/Justfile
+++ b/Justfile
@@ -42,3 +42,11 @@ buildimg chunk="":
 # Run end-to-end tests with built chunkah image
 test *ARGS:
     ./tests/e2e/run.sh {{ ARGS }}
+
+# Profile chunkah with flamegraph (outputs flamegraph.svg)
+profile *ARGS:
+    just -f tools/perf/Justfile profile {{ ARGS }}
+
+# Benchmark chunkah with hyperfine
+benchmark *ARGS:
+    just -f tools/perf/Justfile benchmark {{ ARGS }}

--- a/src/components/bigfiles.rs
+++ b/src/components/bigfiles.rs
@@ -1,0 +1,239 @@
+use std::collections::HashMap;
+
+use camino::{Utf8Path, Utf8PathBuf};
+use indexmap::IndexSet;
+
+use super::{ComponentId, ComponentInfo, ComponentsRepo, FileMap, FileType};
+
+/// Minimum file size in bytes to be considered a "big file" (1 MB).
+const MIN_SIZE: u64 = 1024 * 1024;
+
+const REPO_NAME: &str = "bigfiles";
+
+/// Big files component repo implementation.
+///
+/// Claims any file larger than 1 MB into separate standalone components. This
+/// solves a conceptual issue in the unclaimed files logic: by grouping together
+/// all those files, they can't ever be broken back out into separate layers;
+/// the packer considers each component as one monolithic unit. By breaking them
+/// out, the packer can choose to merge them back in (or leave them separate)
+/// as it sees fit. Conceptually, every unclaimed file should be considered
+/// separately, but it's overkill to be this granular so we just filter for >1M.
+///
+/// Some special handling for hardlinked files (same inode); we still want
+/// unclaimed files that are hardlinked to end up in the same component.
+pub struct BigfilesRepo {
+    /// Component names, indexed by ComponentId.
+    components: IndexSet<String>,
+    /// Mapping from path to ComponentId.
+    path_to_component: HashMap<Utf8PathBuf, ComponentId>,
+    /// Default mtime clamp for components.
+    default_mtime_clamp: u64,
+}
+
+impl BigfilesRepo {
+    /// Load bigfiles repo by scanning for files >= MIN_SIZE.
+    ///
+    /// Returns None if no qualifying files are found. Hardlinked files (same
+    /// inode, nlink > 1) are grouped into the same component.
+    pub fn load(files: &FileMap, default_mtime_clamp: u64) -> Option<Self> {
+        let mut components: IndexSet<String> = IndexSet::new();
+        let mut path_to_component: HashMap<Utf8PathBuf, ComponentId> = HashMap::new();
+
+        // build inode table for hardlink handling
+        let mut inode_to_paths: HashMap<u64, Vec<&Utf8PathBuf>> = HashMap::new();
+        for (path, file_info) in files {
+            if file_info.file_type == FileType::File
+                && file_info.nlink > 1
+                && file_info.size >= MIN_SIZE
+            {
+                inode_to_paths.entry(file_info.ino).or_default().push(path);
+            }
+        }
+
+        for (path, file_info) in files {
+            if file_info.file_type != FileType::File || file_info.size < MIN_SIZE {
+                continue;
+            }
+
+            // skip if this inode was already processed via an earlier hardlink
+            if file_info.nlink > 1 && !inode_to_paths.contains_key(&file_info.ino) {
+                continue;
+            }
+
+            let filename = path
+                .file_name()
+                .map(|s| s.to_string())
+                .expect("filename has no basename");
+
+            // derive component name from filename
+            let component_name = if components.contains(&filename) {
+                // filename already used, use full path without leading '/'
+                path.strip_prefix("/")
+                    .expect("non-absolute file path in FileMap")
+                    .as_str()
+                    .to_string()
+            } else {
+                filename
+            };
+
+            // create a component for this path
+            let (idx, _) = components.insert_full(component_name);
+            let component_id = ComponentId(idx);
+            path_to_component.insert(path.clone(), component_id);
+
+            // if it has hardlinks, also shove those into the same component
+            if let Some(linked_paths) = inode_to_paths.remove(&file_info.ino) {
+                for linked_path in linked_paths {
+                    path_to_component.insert(linked_path.clone(), component_id);
+                }
+            }
+        }
+
+        if components.is_empty() {
+            return None;
+        }
+
+        Some(Self {
+            components,
+            path_to_component,
+            default_mtime_clamp,
+        })
+    }
+}
+
+impl ComponentsRepo for BigfilesRepo {
+    fn name(&self) -> &'static str {
+        REPO_NAME
+    }
+
+    fn default_priority(&self) -> usize {
+        80
+    }
+
+    fn claims_for_path(&self, path: &Utf8Path, _file_type: FileType) -> Vec<ComponentId> {
+        self.path_to_component
+            .get(path)
+            .map(|id| vec![*id])
+            .unwrap_or_default()
+    }
+
+    fn component_info(&self, id: ComponentId) -> ComponentInfo<'_> {
+        ComponentInfo {
+            name: self
+                .components
+                .get_index(id.0)
+                // SAFETY: the ids we're given come from the IndexSet itself
+                // when we inserted the element, so it must be valid.
+                .expect("invalid ComponentId"),
+            mtime_clamp: self.default_mtime_clamp,
+            stability: 0.0,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use cap_std_ext::cap_std::ambient_authority;
+    use cap_std_ext::cap_std::fs::Dir;
+
+    use super::*;
+
+    /// Helper to set up a rootfs, run setup, and scan files.
+    /// Returns (tempdir, files) - caller must keep tempdir alive.
+    fn setup_rootfs<F>(setup: F) -> (tempfile::TempDir, FileMap)
+    where
+        F: FnOnce(&Dir),
+    {
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = Dir::open_ambient_dir(tmp.path(), ambient_authority()).unwrap();
+        setup(&rootfs);
+        let files = crate::scan::Scanner::new(&rootfs).scan().unwrap();
+        (tmp, files)
+    }
+
+    /// Helper to create a sparse file with the given size (uses no disk space).
+    fn create_sparse_file(rootfs: &Dir, path: &str, size: u64) {
+        let file = rootfs.create(path).unwrap();
+        file.set_len(size).unwrap();
+    }
+
+    /// Helper to assert a path is claimed by a specific component.
+    fn assert_component(repo: &BigfilesRepo, path: &str, expected: &str) {
+        let claims = repo.claims_for_path(Utf8Path::new(path), FileType::File);
+        assert_eq!(claims.len(), 1, "{path} should have exactly one claim");
+        assert_eq!(
+            repo.component_info(claims[0]).name,
+            expected,
+            "{path} should be claimed by {expected}"
+        );
+    }
+
+    #[test]
+    fn test_bigfiles_claims_large_files() {
+        let tmp = tempfile::tempdir().unwrap();
+        let rootfs = Dir::open_ambient_dir(tmp.path(), ambient_authority()).unwrap();
+
+        rootfs.create_dir_all("usr/bin").unwrap();
+        rootfs.write("usr/bin/small", "x").unwrap(); // < 1 MB
+
+        rootfs.create_dir_all("usr/lib/modules").unwrap();
+        create_sparse_file(&rootfs, "usr/lib/modules/initramfs.img", 118 * 1024 * 1024);
+
+        rootfs
+            .create_dir_all("usr/lib/sysimage/rpm-ostree-base-db")
+            .unwrap();
+        rootfs.create_dir_all("usr/share/rpm").unwrap();
+        create_sparse_file(
+            &rootfs,
+            "usr/lib/sysimage/rpm-ostree-base-db/rpmdb.sqlite",
+            26 * 1024 * 1024,
+        );
+        std::fs::hard_link(
+            tmp.path()
+                .join("usr/lib/sysimage/rpm-ostree-base-db/rpmdb.sqlite"),
+            tmp.path().join("usr/share/rpm/rpmdb.sqlite"),
+        )
+        .unwrap();
+
+        let rootfs = Dir::open_ambient_dir(tmp.path(), ambient_authority()).unwrap();
+        let files = crate::scan::Scanner::new(&rootfs).scan().unwrap();
+
+        let repo = BigfilesRepo::load(&files, 12345).unwrap();
+
+        // small file should not be claimed
+        let claims = repo.claims_for_path(Utf8Path::new("/usr/bin/small"), FileType::File);
+        assert!(claims.is_empty());
+
+        // large files should be claimed with their filename
+        assert_component(&repo, "/usr/lib/modules/initramfs.img", "initramfs.img");
+
+        // hardlinked files should be claimed by the same component
+        assert_component(
+            &repo,
+            "/usr/lib/sysimage/rpm-ostree-base-db/rpmdb.sqlite",
+            "rpmdb.sqlite",
+        );
+        assert_component(&repo, "/usr/share/rpm/rpmdb.sqlite", "rpmdb.sqlite");
+
+        // there should be exactly 2 components (initramfs.img + rpmdb.sqlite)
+        assert_eq!(repo.components.len(), 2);
+    }
+
+    #[test]
+    fn test_bigfiles_duplicate_filenames() {
+        let (_tmp, files) = setup_rootfs(|rootfs| {
+            rootfs.create_dir("a").unwrap();
+            rootfs.create_dir("b").unwrap();
+
+            create_sparse_file(rootfs, "a/foobar", 4 * 1024 * 1024);
+            create_sparse_file(rootfs, "b/foobar", 4 * 1024 * 1024);
+        });
+
+        let repo = BigfilesRepo::load(&files, 0).unwrap();
+
+        // First one uses filename, second uses full path
+        assert_component(&repo, "/a/foobar", "foobar");
+        assert_component(&repo, "/b/foobar", "b/foobar");
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,3 +1,4 @@
+mod bigfiles;
 mod rpm;
 mod xattr;
 
@@ -123,6 +124,10 @@ impl ComponentsRepos {
             repos.push(Box::new(repo));
         }
 
+        if let Some(repo) = bigfiles::BigfilesRepo::load(files, default_mtime_clamp) {
+            repos.push(Box::new(repo));
+        }
+
         // Other backends (e.g. deb, apk, pip, etc.) would go here...
 
         Ok(Self {
@@ -197,10 +202,10 @@ impl ComponentsRepos {
             );
         }
 
-        // Final pass: fill in stability for components with 0.0 (xattr, unclaimed).
-        // Use half the minimum non-zero stability so they're considered less stable
-        // than any known component, but non-zero so the packing algorithm can make
-        // meaningful TEV loss calculations.
+        // Final pass: fill in stability for components with 0.0 (xattr,
+        // bigfiles, unclaimed). Use half the minimum non-zero stability so
+        // they're considered less stable than any known component, but non-zero
+        // so the packing algorithm can make meaningful TEV loss calculations.
         let min_stability = components
             .values()
             .map(|c| c.stability)

--- a/tests/e2e/test-fcos.sh
+++ b/tests/e2e/test-fcos.sh
@@ -35,12 +35,11 @@ assert_has_components "${CHUNKED_IMAGE}" "rpm/kernel" "rpm/systemd" "rpm/ignitio
 # verify we got exactly 96 layers
 assert_layer_count "${CHUNKED_IMAGE}" 96
 
-# verify unclaimed layer is under 300MB (314572800 bytes)
-# XXX: we're working towards reworking unclaimed logic which should allow us to lower the threshold here
+# verify layer containing unclaimed is under 50MB (52428800 bytes)
 unclaimed_size=$(skopeo inspect "containers-storage:${CHUNKED_IMAGE}" | \
     jq '.LayersData[] | select(.Annotations["org.chunkah.component"] | contains("chunkah/unclaimed")) | .Size')
 [[ -n "${unclaimed_size}" ]]
-[[ ${unclaimed_size} -le 314572800 ]]
+[[ ${unclaimed_size} -le 52428800 ]]
 
 # verify chunked image is not larger than original + 1%
 # (catches possible e.g. bad hardlink handling)

--- a/tools/inspect-layers.sh
+++ b/tools/inspect-layers.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+set -euo pipefail
+shopt -s inherit_errexit
+
+# Inspect layers of a chunkah-split image, showing size, stability, and components.
+
+usage() {
+    cat <<EOF
+Usage: $(basename "$0") [OPTIONS] <image>
+
+Inspect layers of a chunkah-split image, showing size, stability, and components.
+
+Options:
+    -n, --top N            Show only the top N layers (default: all)
+    -s, --sort-by FIELD    Sort by field: size (default) or stability
+    -r, --reverse          Reverse the sort order
+    -h, --help             Show this help message
+
+Arguments:
+    image                  Image reference (e.g. containers-storage:localhost/myimage:latest,
+                           oci-archive:/path/to/image.ociarchive)
+
+Examples:
+    $(basename "$0") containers-storage:localhost/fcos-chunked:latest
+    $(basename "$0") oci-archive:/tmp/image.ociarchive
+    $(basename "$0") --top 20 containers-storage:localhost/fcos-chunked:latest
+    $(basename "$0") --sort-by stability oci-archive:/tmp/image.ociarchive
+EOF
+}
+
+# Parse options
+top_n=""
+sort_by="size"
+reverse=false
+while [[ $# -gt 0 ]]; do
+    case "${1}" in
+        -n|--top)
+            top_n="${2}"
+            shift 2
+            ;;
+        -s|--sort-by)
+            sort_by="${2}"
+            if [[ "${sort_by}" != "size" && "${sort_by}" != "stability" ]]; then
+                echo "Error: --sort-by must be 'size' or 'stability'" >&2
+                exit 1
+            fi
+            shift 2
+            ;;
+        -r|--reverse)
+            reverse=true
+            shift
+            ;;
+        -h|--help)
+            usage
+            exit 0
+            ;;
+        -*)
+            echo "Unknown option: ${1}" >&2
+            usage >&2
+            exit 1
+            ;;
+        *)
+            break
+            ;;
+    esac
+done
+
+if [[ $# -ne 1 ]]; then
+    usage >&2
+    exit 1
+fi
+
+image="${1}"
+
+# Get layer data from skopeo
+layer_data=$(skopeo inspect "${image}" | jq -r '
+    .LayersData[] |
+    {
+        size: .Size,
+        component: (.Annotations["org.chunkah.component"] // "unknown"),
+        stability: (.Annotations["org.chunkah.stability"] // "unknown")
+    }
+')
+
+if [[ -z "${layer_data}" ]]; then
+    echo "Error: Could not inspect image or no layers found" >&2
+    exit 1
+fi
+
+# Count layers
+layer_count=$(echo "${layer_data}" | jq -s 'length')
+
+echo "=== Chunkah Layer Breakdown ==="
+echo ""
+echo "Total layers: ${layer_count}"
+echo ""
+printf "%-12s %-10s %-60s\n" "Size (MB)" "Stability" "Components"
+printf "%-12s %-10s %-60s\n" "----------" "---------" "------------------------------------------------------------"
+
+# Sort and optionally limit layers
+sort_and_limit() {
+    local sort_flags="-n"
+    if [[ "${sort_by}" == "stability" ]]; then
+        # Sort by stability (column 2), descending by default (most stable first)
+        sort_flags="-k2 -n"
+        if [[ "${reverse}" == "false" ]]; then
+            sort_flags="${sort_flags}r"
+        fi
+    else
+        # Sort by size (column 1), descending by default (largest first)
+        sort_flags="-k1 -n"
+        if [[ "${reverse}" == "false" ]]; then
+            sort_flags="${sort_flags}r"
+        fi
+    fi
+    # shellcheck disable=SC2086
+    sort -t'	' ${sort_flags} | if [[ -n "${top_n}" ]]; then head -n "${top_n}"; else cat; fi
+}
+
+echo "${layer_data}" | jq -r '[.size, .stability, .component] | @tsv' | \
+    sort_and_limit | \
+    while IFS=$'\t' read -r size stability comps; do
+        size_mb=$(printf "%.2f" "$(echo "${size} / 1024 / 1024" | bc -l)" || true)
+
+        # Truncate long component lists
+        if [[ ${#comps} -gt 58 ]]; then
+            comp_count=$(echo "${comps}" | wc -w)
+            first_comps=$(echo "${comps}" | cut -d' ' -f1-3)
+            comps="${first_comps} ... (+$(( comp_count - 3 )) more)"
+        fi
+
+        # Format stability (truncate to 3 decimal places if numeric)
+        if [[ "${stability}" =~ ^[0-9.]+$ ]]; then
+            stability=$(printf "%.3f" "${stability}")
+        fi
+
+        printf "%10s   %-10s %s\n" "${size_mb}" "${stability}" "${comps}"
+    done

--- a/tools/perf/Containerfile
+++ b/tools/perf/Containerfile
@@ -1,0 +1,9 @@
+ARG BASE=quay.io/fedora/fedora-minimal:43
+
+FROM ${BASE}
+RUN --mount=type=cache,rw,id=dnf,target=/var/cache/libdnf5 \
+    dnf install -y cargo rust pkg-config openssl-devel perf
+RUN --mount=type=cache,rw,id=cargo,target=/root/.cargo \
+    cargo install flamegraph hyperfine --root /usr/local
+ENV CHUNKAH_ROOTFS=/chunkah
+WORKDIR /build

--- a/tools/perf/Justfile
+++ b/tools/perf/Justfile
@@ -1,0 +1,34 @@
+# Common podman run args for perf container
+_perf_run_args := "--rm \
+    --security-opt=label=disable \
+    -v chunkah-perf-cargo:/root/.cargo \
+    -v chunkah-perf-target:/tmp/target \
+    -e CARGO_TARGET_DIR=/tmp/target \
+    -e CARGO_PROFILE_RELEASE_DEBUG=true \
+    chunkah-perf"
+
+# Build performance analysis container image
+_buildperfimg:
+    ${BUILDAH:-buildah} build --layers=true -t chunkah-perf -f Containerfile ../..
+
+# Profile chunkah with flamegraph (outputs flamegraph.svg)
+profile image="quay.io/fedora/fedora-minimal:latest": _buildperfimg
+    #!/bin/bash
+    set -euo pipefail
+    podman pull --policy=missing {{ image }}
+    podman run --privileged -v "${PWD}/../..:/build:z" \
+        --mount=type=image,src={{ image }},target=/chunkah \
+        {{ _perf_run_args }} \
+        sh -c 'cargo flamegraph -o /build/flamegraph.svg -- build --prune /sysroot/ > /dev/null'
+
+    echo "Flamegraph written to flamegraph.svg"
+
+# Benchmark chunkah with hyperfine
+benchmark image="quay.io/fedora/fedora-minimal:latest": _buildperfimg
+    #!/bin/bash
+    set -euo pipefail
+    podman pull --policy=missing {{ image }}
+    podman run -v "${PWD}/../..:/build:z" \
+        --mount=type=image,src={{ image }},target=/chunkah \
+        {{ _perf_run_args }} \
+        sh -c 'cargo build --release && hyperfine --warmup 1 "/tmp/target/release/chunkah build --prune /sysroot/ > /dev/null"'


### PR DESCRIPTION
Add a new component repo that claims unclaimed files >= 1 MB into separate standalone components. This solves a conceptual issue in the unclaimed files logic: by grouping all unclaimed files together, they can't ever be broken back out into separate layers since the packer considers each component as one monolithic unit. By breaking out large files, the packer can choose to merge them back in (or leave them separate) as it sees fit.

Conceptually, every unclaimed file should be considered separately, but it's overkill to be this granular so we just filter for >= 1 MB. Files like initramfs.img and rpmdb.sqlite are good examples of large volatile files that benefit from being in their own layers.

Hardlinked files (same inode) are grouped into the same component so that tar can emit them properly as hardlinks.

On FCOS, this drops the unclaimed component from ~165 MB to ~9 MB by extracting just 5 files totaling 156 MB.

Assisted-by: Claude Opus 4.5
