### PR TITLE
tools/release: add Containerfile.splitter as release asset

### DIFF
--- a/tools/release.py
+++ b/tools/release.py
@@ -70,7 +70,7 @@ def main():
             print("To complete the release, run:")
             print(f"  git push origin {tag}")
             print(f"  gh release create {tag} --notes-from-tag --verify-tag "
-                  f"{source_tarball} {vendor_tarball}")
+                  f"{source_tarball} {vendor_tarball} Containerfile.splitter")
             print(f"  rm {source_tarball} {vendor_tarball}")
         else:
             step("Pushing tag...")
@@ -78,7 +78,8 @@ def main():
 
             step("Creating GitHub release...")
             run("gh", "release", "create", tag, "--notes-from-tag",
-                "--verify-tag", source_tarball, vendor_tarball)
+                "--verify-tag", source_tarball, vendor_tarball,
+                "Containerfile.splitter")
 
             step("Cleaning up tarballs...")
             os.remove(source_tarball)


### PR DESCRIPTION
Include the splitter Containerfile in GitHub releases. Still thinking about this, this file is meant to be used directly via HTTP but because it's an end-user API, I want it to be:
1. accessible through a not-too-ugly URL
2. versioned somehow so users can pin version and we can make changes

Assisted-by: Claude Opus 4.5