### PR TITLE
README.md: fix Containerfile.splitter URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ use the `Containerfile.splitter`, passing the target image as the `--from`:
 IMG=quay.io/fedora/fedora-minimal:latest
 buildah build --skip-unused-stages=false --from $IMG \
   --build-arg CHUNKAH_CONFIG_STR="$(podman inspect $IMG)" \
-  https://github.com/jlebon/chunkah/releases/download/latest/Containerfile.splitter
+  https://github.com/jlebon/chunkah/releases/download/v0.1.0/Containerfile.splitter
 ```
 
 Additional arguments can be passed to chunkah using the CHUNKAH_ARGS build


### PR DESCRIPTION
For some reason, I can't get the `latest` link to work. So let's just use what we have for now.