### PR TITLE
README.md: bump Containerfile.splitter versioned URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,15 +13,16 @@ jobs:
     container: quay.io/fedora/fedora:latest
     steps:
       - name: Install tools
-        run: dnf install -y cargo clippy rustfmt just ShellCheck nodejs-npm openssl-devel git
+        run: dnf install -y cargo clippy rustfmt just ShellCheck nodejs-npm openssl-devel git jq
       - name: Configure git
         run: git config --global --add safe.directory '*'
       - name: Checkout
         uses: actions/checkout@v6
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
-      - name: Verify Cargo.lock is in sync
-        run: just lockcheck
+        # do this first to avoid building implicitly bumping the lockfile
+      - name: Verify Cargo.lock and README.md are in sync
+        run: just versioncheck
       - name: Build
         run: just build
       - name: Check

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ use the `Containerfile.splitter`, passing the target image as the `--from`:
 IMG=quay.io/fedora/fedora-minimal:latest
 buildah build --skip-unused-stages=false --from $IMG \
   --build-arg CHUNKAH_CONFIG_STR="$(podman inspect $IMG)" \
-  https://github.com/jlebon/chunkah/releases/download/v0.1.0/Containerfile.splitter
+  https://github.com/jlebon/chunkah/releases/download/v0.1.1/Containerfile.splitter
 ```
 
 Additional arguments can be passed to chunkah using the CHUNKAH_ARGS build

--- a/tools/release.py
+++ b/tools/release.py
@@ -31,8 +31,9 @@ def main():
         if is_worktree_dirty():
             die("Worktree is dirty, commit or stash changes first")
 
-        step("Verifying Cargo.lock is in sync...")
-        run("just", "lockcheck")
+        # do this first to avoid building implicitly bumping the lockfile
+        step("Verifying Cargo.lock and README.md are in sync...")
+        run("just", "versioncheck")
 
         step("Running checks...")
         run("just", "checkall")


### PR DESCRIPTION
Let's just have it always match the latest release.

Generalize the `lockcheck` CI check to become `versioncheck`, which also covers the README.md. The grep lines are a bit yucky but meh.

Assisted-by: Claude Opus 4.5