### PR TITLE
ocibuilder: emit history entries with component info

### DIFF
--- a/tests/e2e/test-fcos.sh
+++ b/tests/e2e/test-fcos.sh
@@ -35,11 +35,11 @@ assert_has_components "${CHUNKED_IMAGE}" "rpm/kernel" "rpm/systemd" "rpm/ignitio
 # verify we got exactly 96 layers
 assert_layer_count "${CHUNKED_IMAGE}" 96
 
-# verify layer containing unclaimed is under 50MB (52428800 bytes)
+# verify layer containing unclaimed is under 100MB (104857600 bytes)
 unclaimed_size=$(skopeo inspect "containers-storage:${CHUNKED_IMAGE}" | \
     jq '.LayersData[] | select(.Annotations["org.chunkah.component"] | contains("chunkah/unclaimed")) | .Size')
 [[ -n "${unclaimed_size}" ]]
-[[ ${unclaimed_size} -le 52428800 ]]
+[[ ${unclaimed_size} -le 104857600 ]]
 
 # verify chunked image is not larger than original + 1%
 # (catches possible e.g. bad hardlink handling)


### PR DESCRIPTION
Add OCI history entries for each layer we emit. AIUI, history is not mandated by the OCI image spec and while most tools handle images without it fine (buildah even has a `--omit-history` flag), some currently break (e.g. bootc). We could fix issues where we encounter them, but it's much easier to match the rest of the ecosystem and have it.

As a bonus, this gives us a more reliable way to retain component information than via layer annotations (see e.g. https://github.com/containers/buildah/issues/6652). And there's tooling like `podman history` built to display that info more easily.

Assisted-by: Claude Opus 4.5