### PR TITLE
tools: add scripts to analyze layer reuse across image updates

### DIFF
--- a/tools/analyze-layer-reuse.py
+++ b/tools/analyze-layer-reuse.py
@@ -1,0 +1,437 @@
+#!/usr/bin/env python3
+"""Compare sequential images and report layer sharing statistics."""
+
+import argparse
+import json
+import subprocess
+import sys
+from dataclasses import dataclass
+
+
+@dataclass
+class LayerInfo:
+    """Information about a single layer."""
+    digest: str
+    size: int  # Compressed size (download size) from LayersData[].Size
+    component: str | None  # From LayersData[].Annotations["org.chunkah.component"]
+
+
+@dataclass
+class ImageInfo:
+    """Information about an image's layers."""
+    ref: str
+    tag: str
+    original_tag: str | None  # From annotation org.chunkah.original-tag
+    layers: list[LayerInfo]
+    total_size: int
+
+
+@dataclass
+class UpdateAnalysis:
+    """Analysis of layer changes between two images."""
+    from_tag: str
+    to_tag: str
+    from_original: str | None
+    to_original: str | None
+    shared_layers: list[LayerInfo]
+    added_layers: list[LayerInfo]
+    removed_layers: list[LayerInfo]
+    shared_bytes: int
+    download_bytes: int
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Compare sequential images and report layer sharing statistics"
+    )
+    parser.add_argument(
+        "prefix",
+        help="containers-storage prefix (e.g., localhost/fcos-chunked)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="json_output",
+        help="Output as JSON",
+    )
+    parser.add_argument(
+        "--show-components",
+        action="store_true",
+        help="Show which components changed in each update",
+    )
+    parser.add_argument(
+        "--compare-originals",
+        action="store_true",
+        help="Also analyze original images ({prefix}-orig) for comparison",
+    )
+    args = parser.parse_args()
+
+    try:
+        # Find all images with the prefix
+        image_refs = find_images(args.prefix)
+
+        if not image_refs:
+            die(f"No images found with prefix '{args.prefix}'")
+
+        if len(image_refs) == 1:
+            print("Warning: Only 1 image found. Need at least 2 for update analysis.",
+                  file=sys.stderr)
+
+        # Get info for each image
+        images = []
+        for ref in image_refs:
+            images.append(get_image_info(ref, args.prefix))
+
+        # Analyze sequential updates
+        analyses = []
+        for i in range(len(images) - 1):
+            analyses.append(analyze_update(images[i], images[i + 1]))
+
+        # Optionally analyze original images for comparison
+        orig_images = []
+        orig_analyses = []
+        if args.compare_originals:
+            orig_prefix = f"{args.prefix}-orig"
+            orig_refs = find_images(orig_prefix)
+            if not orig_refs:
+                print(f"Warning: No original images found at '{orig_prefix}'",
+                      file=sys.stderr)
+            else:
+                for ref in orig_refs:
+                    orig_images.append(get_image_info(ref, orig_prefix))
+                for i in range(len(orig_images) - 1):
+                    orig_analyses.append(analyze_update(orig_images[i], orig_images[i + 1]))
+
+        # Output results
+        if args.json_output:
+            print(format_json_output(images, analyses, orig_images, orig_analyses))
+        else:
+            print(format_human_output(images, analyses, orig_images, orig_analyses,
+                                      args.show_components))
+
+    except subprocess.CalledProcessError as e:
+        die(f"Command failed: {e.cmd}")
+    except Exception as e:
+        die(str(e))
+
+
+def find_images(prefix: str) -> list[str]:
+    """Find all images matching prefix:0, prefix:1, etc."""
+    try:
+        output = run_output(
+            "podman", "images", "--format", "{{.Repository}}:{{.Tag}}",
+            prefix
+        )
+    except subprocess.CalledProcessError:
+        return []
+
+    refs = [line.strip() for line in output.strip().split("\n") if line.strip()]
+
+    # Filter to only those with numeric tags and sort by index
+    numeric_refs = []
+    for ref in refs:
+        try:
+            idx = _parse_tag_index(ref, prefix)
+            numeric_refs.append((idx, ref))
+        except ValueError:
+            continue
+
+    numeric_refs.sort(key=lambda x: x[0])
+    return [ref for _, ref in numeric_refs]
+
+
+def get_image_info(image_ref: str, prefix: str) -> ImageInfo:
+    """Get layer information for an image via skopeo."""
+    output = run_output("skopeo", "inspect", f"containers-storage:{image_ref}")
+    data = json.loads(output)
+
+    layers = []
+    total_size = 0
+
+    for layer_data in data.get("LayersData", []):
+        digest = layer_data.get("Digest", "")
+        size = layer_data.get("Size", 0)
+        annotations = layer_data.get("Annotations", {}) or {}
+        component = annotations.get("org.chunkah.component")
+
+        layers.append(LayerInfo(digest=digest, size=size, component=component))
+        total_size += size
+
+    # Get original tag from labels if available
+    original_tag = None
+    labels = data.get("Labels", {}) or {}
+    original_tag = labels.get("org.chunkah.original-tag")
+
+    tag = image_ref.split(":")[-1] if ":" in image_ref else ""
+
+    return ImageInfo(
+        ref=image_ref,
+        tag=tag,
+        original_tag=original_tag,
+        layers=layers,
+        total_size=total_size,
+    )
+
+
+def analyze_update(from_img: ImageInfo, to_img: ImageInfo) -> UpdateAnalysis:
+    """Compare two images and calculate layer differences."""
+    from_digests = {layer.digest: layer for layer in from_img.layers}
+    to_digests = {layer.digest: layer for layer in to_img.layers}
+
+    shared_layers = []
+    added_layers = []
+    removed_layers = []
+
+    # Find shared and added layers
+    for digest, layer in to_digests.items():
+        if digest in from_digests:
+            shared_layers.append(layer)
+        else:
+            added_layers.append(layer)
+
+    # Find removed layers
+    for digest, layer in from_digests.items():
+        if digest not in to_digests:
+            removed_layers.append(layer)
+
+    shared_bytes = sum(layer.size for layer in shared_layers)
+    download_bytes = sum(layer.size for layer in added_layers)
+
+    return UpdateAnalysis(
+        from_tag=from_img.tag,
+        to_tag=to_img.tag,
+        from_original=from_img.original_tag,
+        to_original=to_img.original_tag,
+        shared_layers=shared_layers,
+        added_layers=added_layers,
+        removed_layers=removed_layers,
+        shared_bytes=shared_bytes,
+        download_bytes=download_bytes,
+    )
+
+
+def format_human_output(images: list[ImageInfo], analyses: list[UpdateAnalysis],
+                        orig_images: list[ImageInfo], orig_analyses: list[UpdateAnalysis],
+                        show_components: bool) -> str:
+    """Format analysis results for human consumption."""
+    lines = []
+
+    # Header
+    if images:
+        first_tag = images[0].tag
+        last_tag = images[-1].tag
+        lines.append(f"==> Found {len(images)} chunked images: {images[0].ref.rsplit(':', 1)[0]}:{first_tag} through :{last_tag}")
+        lines.append("")
+
+    # Image summary
+    lines.append("==> Chunked Image Summary:")
+    for img in images:
+        original = f" ({img.original_tag})" if img.original_tag else ""
+        size_str = _format_bytes(img.total_size)
+        lines.append(f"    :{img.tag}{original}  {len(img.layers)} layers, {size_str}")
+    lines.append("")
+
+    # Update analysis
+    if analyses:
+        lines.append("==> Chunked Update Analysis:")
+        lines.append("")
+
+        for analysis in analyses:
+            from_str = f":{analysis.from_tag}"
+            to_str = f":{analysis.to_tag}"
+            if analysis.from_original and analysis.to_original:
+                from_str += f" ({analysis.from_original})"
+                to_str += f" ({analysis.to_original})"
+
+            total_layers = len(analysis.shared_layers) + len(analysis.added_layers)
+            reuse_ratio = len(analysis.shared_layers) / total_layers if total_layers > 0 else 0
+
+            lines.append(f"    {from_str} -> {to_str}")
+            lines.append(f"    Shared:   {len(analysis.shared_layers):3} layers ({_format_bytes(analysis.shared_bytes)})")
+            lines.append(f"    Added:    {len(analysis.added_layers):3} layers ({_format_bytes(analysis.download_bytes)} download)")
+            lines.append(f"    Removed:  {len(analysis.removed_layers):3} layers")
+            lines.append(f"    Reuse:    {reuse_ratio * 100:.1f}%")
+
+            if show_components and analysis.added_layers:
+                added_components = sorted(set(
+                    layer.component for layer in analysis.added_layers
+                    if layer.component
+                ))
+                if added_components:
+                    lines.append(f"    Changed components: {', '.join(added_components[:5])}")
+                    if len(added_components) > 5:
+                        lines.append(f"                        ... and {len(added_components) - 5} more")
+
+            lines.append("")
+
+    # Summary statistics for chunked
+    if analyses:
+        summary = _calculate_summary(analyses)
+        lines.append("==> Chunked Summary:")
+        lines.append(f"    Total updates analyzed: {summary['update_count']}")
+        lines.append(f"    Average layer reuse:    {summary['avg_reuse_ratio'] * 100:.1f}%")
+        lines.append(f"    Average download size:  {_format_bytes(summary['avg_download_bytes'])}")
+
+        if summary['update_count'] > 1:
+            lines.append(f"    Min download:           {_format_bytes(summary['min_download_bytes'])}")
+            lines.append(f"    Max download:           {_format_bytes(summary['max_download_bytes'])}")
+        lines.append("")
+
+    # Original image comparison (if available)
+    if orig_images and orig_analyses:
+        lines.append("==> Original (un-chunked) Update Analysis:")
+        lines.append("")
+
+        for analysis in orig_analyses:
+            total_layers = len(analysis.shared_layers) + len(analysis.added_layers)
+            reuse_ratio = len(analysis.shared_layers) / total_layers if total_layers > 0 else 0
+
+            lines.append(f"    :{analysis.from_tag} -> :{analysis.to_tag}")
+            lines.append(f"    Shared:   {len(analysis.shared_layers):3} layers ({_format_bytes(analysis.shared_bytes)})")
+            lines.append(f"    Added:    {len(analysis.added_layers):3} layers ({_format_bytes(analysis.download_bytes)} download)")
+            lines.append(f"    Reuse:    {reuse_ratio * 100:.1f}%")
+            lines.append("")
+
+        orig_summary = _calculate_summary(orig_analyses)
+        lines.append("==> Original Summary:")
+        lines.append(f"    Average layer reuse:    {orig_summary['avg_reuse_ratio'] * 100:.1f}%")
+        lines.append(f"    Average download size:  {_format_bytes(orig_summary['avg_download_bytes'])}")
+        lines.append("")
+
+        # Comparison
+        if analyses:
+            chunked_summary = _calculate_summary(analyses)
+            lines.append("==> Comparison (Chunked vs Original):")
+            savings = orig_summary['avg_download_bytes'] - chunked_summary['avg_download_bytes']
+            savings_pct = (savings / orig_summary['avg_download_bytes'] * 100
+                          if orig_summary['avg_download_bytes'] > 0 else 0)
+            lines.append(f"    Download savings:       {_format_bytes(savings)} ({savings_pct:.1f}% smaller)")
+            lines.append(f"    Layer reuse improvement: {(chunked_summary['avg_reuse_ratio'] - orig_summary['avg_reuse_ratio']) * 100:+.1f}%")
+
+    return "\n".join(lines)
+
+
+def format_json_output(images: list[ImageInfo], analyses: list[UpdateAnalysis],
+                       orig_images: list[ImageInfo],
+                       orig_analyses: list[UpdateAnalysis]) -> str:
+    """Format analysis results as JSON."""
+
+    def _format_image(img: ImageInfo) -> dict:
+        return {
+            "ref": img.ref,
+            "tag": img.tag,
+            "original_tag": img.original_tag,
+            "layer_count": len(img.layers),
+            "total_bytes": img.total_size,
+            "layers": [
+                {
+                    "digest": layer.digest,
+                    "size": layer.size,
+                    "component": layer.component,
+                }
+                for layer in img.layers
+            ],
+        }
+
+    def _format_analysis(analysis: UpdateAnalysis) -> dict:
+        total = len(analysis.shared_layers) + len(analysis.added_layers)
+        return {
+            "from": analysis.from_tag,
+            "to": analysis.to_tag,
+            "from_original": analysis.from_original,
+            "to_original": analysis.to_original,
+            "shared_layer_count": len(analysis.shared_layers),
+            "added_layer_count": len(analysis.added_layers),
+            "removed_layer_count": len(analysis.removed_layers),
+            "shared_bytes": analysis.shared_bytes,
+            "download_bytes": analysis.download_bytes,
+            "reuse_ratio": len(analysis.shared_layers) / total if total > 0 else 0,
+        }
+
+    output = {
+        "chunked": {
+            "images": [_format_image(img) for img in images],
+            "updates": [_format_analysis(a) for a in analyses],
+            "summary": _calculate_summary(analyses) if analyses else {},
+        },
+    }
+
+    if orig_images or orig_analyses:
+        output["original"] = {
+            "images": [_format_image(img) for img in orig_images],
+            "updates": [_format_analysis(a) for a in orig_analyses],
+            "summary": _calculate_summary(orig_analyses) if orig_analyses else {},
+        }
+
+        # Add comparison if both have data
+        if analyses and orig_analyses:
+            chunked_summary = _calculate_summary(analyses)
+            orig_summary = _calculate_summary(orig_analyses)
+            savings = orig_summary['avg_download_bytes'] - chunked_summary['avg_download_bytes']
+            output["comparison"] = {
+                "download_savings_bytes": savings,
+                "download_savings_ratio": (
+                    savings / orig_summary['avg_download_bytes']
+                    if orig_summary['avg_download_bytes'] > 0 else 0
+                ),
+                "reuse_improvement": (
+                    chunked_summary['avg_reuse_ratio'] - orig_summary['avg_reuse_ratio']
+                ),
+            }
+
+    return json.dumps(output, indent=2)
+
+
+def _parse_tag_index(ref: str, prefix: str) -> int:
+    """Extract numeric index from image reference."""
+    if ":" not in ref:
+        raise ValueError("No tag in reference")
+    tag = ref.split(":")[-1]
+    return int(tag)
+
+
+def _format_bytes(n: int | float) -> str:
+    """Format bytes as human-readable (e.g., 1.5 GiB)."""
+    for unit in ["B", "KiB", "MiB", "GiB", "TiB"]:
+        if abs(n) < 1024:
+            if unit == "B":
+                return f"{int(n)} {unit}"
+            return f"{n:.1f} {unit}"
+        n /= 1024
+    return f"{n:.1f} PiB"
+
+
+def _calculate_summary(analyses: list[UpdateAnalysis]) -> dict:
+    """Calculate aggregate statistics across all updates."""
+    if not analyses:
+        return {}
+
+    download_bytes = [a.download_bytes for a in analyses]
+    reuse_ratios = []
+    for a in analyses:
+        total = len(a.shared_layers) + len(a.added_layers)
+        if total > 0:
+            reuse_ratios.append(len(a.shared_layers) / total)
+
+    return {
+        "update_count": len(analyses),
+        "avg_reuse_ratio": sum(reuse_ratios) / len(reuse_ratios) if reuse_ratios else 0,
+        "avg_download_bytes": int(sum(download_bytes) / len(download_bytes)),
+        "min_download_bytes": min(download_bytes),
+        "max_download_bytes": max(download_bytes),
+        "total_download_bytes": sum(download_bytes),
+    }
+
+
+def die(msg: str):
+    print(f"Error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def run_output(*args: str) -> str:
+    """Run a command and return its stdout."""
+    return subprocess.check_output(args, text=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/chunk-image-series.py
+++ b/tools/chunk-image-series.py
@@ -1,0 +1,393 @@
+#!/usr/bin/env python3
+"""Pull images from a registry, run chunkah on each, store results."""
+
+import argparse
+import fnmatch
+import json
+import os
+import re
+import subprocess
+import sys
+import tempfile
+
+
+def main():
+    args = parse_args()
+    run_chunking(args)
+
+
+def parse_args() -> argparse.Namespace:
+    """Parse command-line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Pull images from a registry, run chunkah on each, store results",
+        usage="%(prog)s [OPTIONS] REPO [-- CHUNKAH_ARGS...]",
+    )
+    parser.add_argument("repo", help="OCI image repository (e.g., quay.io/fedora/fedora-coreos)")
+    parser.add_argument(
+        "--tag-filter",
+        default="*",
+        help="Glob pattern for tag filtering (default: *)",
+    )
+    parser.add_argument(
+        "--sort-by",
+        choices=["version", "name", "date"],
+        default="version",
+        help="How to sort tags: version (natural sort), name (alphabetical), "
+             "or date (by image creation time) (default: version)",
+    )
+    parser.add_argument(
+        "--limit",
+        type=int,
+        help="Maximum number of images to process (takes the N most recent)",
+    )
+    parser.add_argument(
+        "--prefix",
+        help="Storage prefix (default: derived from repo name)",
+    )
+    parser.add_argument(
+        "--chunkah-image",
+        default="quay.io/jlebon/chunkah",
+        help="Chunkah image to use (default: quay.io/jlebon/chunkah)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Show what would be processed without doing it",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite existing images at prefix",
+    )
+    parser.add_argument(
+        "--keep-originals",
+        action="store_true",
+        help="Also store original (un-chunked) images as {prefix}-orig:N",
+    )
+    parser.add_argument(
+        "-v", "--verbose",
+        action="store_true",
+        help="Verbose output",
+    )
+    parser.add_argument(
+        "chunkah_args",
+        nargs="*",
+        help="Additional arguments to pass to chunkah (after --)",
+    )
+    args = parser.parse_args()
+
+    # Derive prefix from repo name if not specified
+    if args.prefix is None:
+        # e.g., quay.io/fedora/fedora-coreos -> fedora-coreos-chunked
+        repo_name = args.repo.split("/")[-1]
+        args.prefix = f"{repo_name}-chunked"
+
+    return args
+
+
+def run_chunking(args: argparse.Namespace):
+    """Run the chunking pipeline."""
+    try:
+        tags = get_sorted_tags(args)
+
+        if args.dry_run:
+            step("Dry run - would process:")
+            for i, tag in enumerate(tags):
+                print(f"  {args.repo}:{tag} -> localhost/{args.prefix}:{i}")
+                if args.keep_originals:
+                    print(f"    (original -> localhost/{args.prefix}-orig:{i})")
+            if args.chunkah_args:
+                print(f"\nChunkah extra args: {' '.join(args.chunkah_args)}")
+            return
+
+        # Check for existing images
+        if not args.force:
+            existing = _find_existing_images(args.prefix)
+            if args.keep_originals:
+                existing.extend(_find_existing_images(f"{args.prefix}-orig"))
+            if existing:
+                die(f"Images already exist at prefix '{args.prefix}': {existing}\n"
+                    f"Use --force to overwrite")
+
+        # Process each tag
+        processed = []
+        failed = []
+        temp_refs = []
+
+        for i, tag in enumerate(tags):
+            result = process_tag(args, i, len(tags), tag, temp_refs)
+            if result is not None:
+                processed.append(result)
+            else:
+                failed.append(tag)
+
+        # Cleanup temp images
+        if temp_refs:
+            step("Cleaning up temporary images...")
+            cleanup_temp_images(temp_refs)
+
+        print_summary(processed, failed, args.keep_originals)
+
+    except subprocess.CalledProcessError as e:
+        die(f"Command failed: {e.cmd}")
+    except Exception as e:
+        die(str(e))
+
+
+def process_tag(args: argparse.Namespace, i: int, total: int, tag: str,
+                temp_refs: list[str]) -> tuple[int, str, str, str | None] | None:
+    """Process a single tag: pull, chunk, and load.
+
+    Returns tuple of (index, tag, target_ref, orig_ref) on success, None on failure.
+    Appends source_ref to temp_refs for later cleanup.
+    """
+    step(f"Processing tag {i + 1}/{total}: {tag}")
+    source_ref = f"localhost/tmp-chunk-src:{tag}"
+    target_ref = f"localhost/{args.prefix}:{i}"
+    orig_ref = f"localhost/{args.prefix}-orig:{i}" if args.keep_originals else None
+
+    try:
+        print("  Pulling image...")
+        pull_image(args.repo, tag, source_ref, verbose=args.verbose)
+
+        # Keep original if requested (tag it before chunking)
+        if orig_ref:
+            print(f"  Storing original as {orig_ref}...")
+            run("podman", "tag", source_ref, orig_ref)
+
+        temp_refs.append(source_ref)
+
+        print("  Running chunkah...")
+        ociarchive = chunk_image(source_ref, args.chunkah_image, tag,
+                                 chunkah_args=args.chunkah_args,
+                                 verbose=args.verbose)
+
+        print(f"  Loading as {target_ref}...")
+        load_chunked_image(ociarchive, target_ref)
+        os.unlink(ociarchive)
+
+        print(f"  Done: {target_ref}")
+        return (i, tag, target_ref, orig_ref)
+
+    except subprocess.CalledProcessError as e:
+        print(f"  ERROR: Failed to process {tag}: {e}", file=sys.stderr)
+        return None
+
+
+def print_summary(processed: list[tuple], failed: list[str], keep_originals: bool):
+    """Print final summary of processed and failed tags."""
+    print()
+    if processed:
+        step("Done! Chunked images stored as:")
+        for i, tag, ref, orig_ref in processed:
+            print(f"  {ref}  ({tag})")
+        if keep_originals:
+            step("Original images stored as:")
+            for i, tag, ref, orig_ref in processed:
+                if orig_ref:
+                    print(f"  {orig_ref}  ({tag})")
+
+    if failed:
+        print()
+        step("Failed to process:")
+        for tag in failed:
+            print(f"  {tag}")
+        sys.exit(1)
+
+
+def get_sorted_tags(args: argparse.Namespace) -> list[str]:
+    """List, filter, sort, and limit tags from remote registry."""
+    step(f"Listing tags from {args.repo} matching '{args.tag_filter}'...")
+    tags = _list_tags(args.repo, args.tag_filter)
+
+    if not tags:
+        die(f"No tags found matching '{args.tag_filter}'")
+
+    if args.sort_by == "date":
+        step("Fetching image creation dates (this may take a while)...")
+        tags = _sort_tags_by_date(args.repo, tags, verbose=args.verbose)
+    else:
+        tags = _sort_tags(tags, args.sort_by)
+
+    if args.limit:
+        # Take the N most recent (from the end of sorted list)
+        tags = tags[-args.limit:]
+
+    print(f"Found {len(tags)} matching tags")
+    if args.verbose:
+        for tag in tags:
+            print(f"  {tag}")
+
+    return tags
+
+
+def _list_tags(repo: str, pattern: str) -> list[str]:
+    """List tags from remote registry matching glob pattern."""
+    output = run_output("skopeo", "list-tags", f"docker://{repo}")
+    data = json.loads(output)
+    all_tags = data.get("Tags", [])
+    return [tag for tag in all_tags if _match_glob(tag, pattern)]
+
+
+def _sort_tags(tags: list[str], sort_by: str) -> list[str]:
+    """Sort tags by version (natural sort) or name (alphabetical)."""
+    if sort_by == "name":
+        return sorted(tags)
+    else:
+        return sorted(tags, key=_natural_sort_key)
+
+
+def _sort_tags_by_date(repo: str, tags: list[str], verbose: bool = False) -> list[str]:
+    """Sort tags by image creation date (oldest first)."""
+    tag_dates = []
+    for tag in tags:
+        if verbose:
+            print(f"  Inspecting {tag}...")
+        try:
+            created = _get_image_created(repo, tag)
+            tag_dates.append((tag, created))
+        except Exception as e:
+            print(f"  Warning: Could not get date for {tag}: {e}", file=sys.stderr)
+            # Use empty string so it sorts first (oldest)
+            tag_dates.append((tag, ""))
+
+    # Sort by date (ISO 8601 format sorts lexicographically)
+    tag_dates.sort(key=lambda x: x[1])
+    return [tag for tag, _ in tag_dates]
+
+
+def pull_image(repo: str, tag: str, target_ref: str, verbose: bool = False):
+    """Pull image to containers-storage."""
+    cmd = [
+        "skopeo", "copy",
+        f"docker://{repo}:{tag}",
+        f"containers-storage:{target_ref}",
+    ]
+    if verbose:
+        print(f"    Running: {' '.join(cmd)}")
+    run(*cmd)
+
+
+def chunk_image(source_ref: str, chunkah_image: str, original_tag: str,
+                chunkah_args: list[str] | None = None,
+                verbose: bool = False) -> str:
+    """Run chunkah on image, return path to OCI archive."""
+    # Get image config
+    config_str = _get_image_config(source_ref)
+
+    # Create temp file for output
+    fd, ociarchive = tempfile.mkstemp(suffix=".ociarchive")
+    os.close(fd)
+
+    try:
+        cmd = [
+            "podman", "run", "--rm",
+            f"--mount=type=image,src={source_ref},target=/chunkah",
+            "-e", f"CHUNKAH_CONFIG_STR={config_str}",
+            chunkah_image,
+            "build",
+            "--label", f"org.chunkah.original-tag={original_tag}",
+        ]
+        if chunkah_args:
+            cmd.extend(chunkah_args)
+        if verbose:
+            extra_args = ["--label", f"org.chunkah.original-tag={original_tag}"]
+            if chunkah_args:
+                extra_args.extend(chunkah_args)
+            print(f"    Running: podman run --rm --mount=... {chunkah_image} build {' '.join(extra_args)}")
+
+        with open(ociarchive, "wb") as f:
+            subprocess.check_call(cmd, stdout=f)
+
+        return ociarchive
+    except Exception:
+        os.unlink(ociarchive)
+        raise
+
+
+def load_chunked_image(ociarchive: str, target_ref: str):
+    """Load OCI archive into containers-storage with target tag."""
+    # Load the image and capture the ID
+    output = run_output("podman", "load", "-i", ociarchive)
+    # Output is like "Loaded image: sha256:abc123..."
+    image_id = output.strip().split()[-1]
+    if image_id.startswith("sha256:"):
+        image_id = image_id[7:]
+
+    # Tag it with our target reference
+    run("podman", "tag", image_id, target_ref)
+
+
+def cleanup_temp_images(refs: list[str]):
+    """Remove temporary source images from containers-storage."""
+    for ref in refs:
+        try:
+            subprocess.run(
+                ["podman", "rmi", "-f", ref],
+                capture_output=True,
+                check=False,
+            )
+        except Exception:
+            pass  # Ignore cleanup errors
+
+
+def _match_glob(tag: str, pattern: str) -> bool:
+    """Check if tag matches glob pattern."""
+    return fnmatch.fnmatch(tag, pattern)
+
+
+def _natural_sort_key(s: str) -> list:
+    """Generate sort key for natural/version sorting.
+
+    Splits string into numeric and non-numeric parts for proper ordering.
+    e.g., 'stable-41.20240101' < 'stable-41.20240201' < 'stable-42.20240101'
+    """
+    parts = re.split(r"(\d+)", s)
+    return [int(p) if p.isdigit() else p.lower() for p in parts]
+
+
+def _get_image_config(image_ref: str) -> str:
+    """Get podman inspect output for chunkah config."""
+    return run_output("podman", "inspect", image_ref)
+
+
+def _get_image_created(repo: str, tag: str) -> str:
+    """Get image creation date from remote registry."""
+    output = run_output("skopeo", "inspect", f"docker://{repo}:{tag}")
+    data = json.loads(output)
+    return data.get("Created", "")
+
+
+def _find_existing_images(prefix: str) -> list[str]:
+    """Find existing images with the given prefix."""
+    try:
+        output = run_output(
+            "podman", "images", "--format", "{{.Repository}}:{{.Tag}}",
+            f"localhost/{prefix}"
+        )
+        return [line.strip() for line in output.strip().split("\n") if line.strip()]
+    except subprocess.CalledProcessError:
+        return []
+
+
+def step(msg: str):
+    print(f"==> {msg}")
+
+
+def die(msg: str):
+    print(f"Error: {msg}", file=sys.stderr)
+    sys.exit(1)
+
+
+def run(*args: str):
+    """Run a command."""
+    subprocess.check_call(args)
+
+
+def run_output(*args: str) -> str:
+    """Run a command and return its stdout."""
+    return subprocess.check_output(args, text=True)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This allows us to actually evaluate changes to the packing algorithm in a methodical way.

Sample usage for FCOS:

```
tools/chunk-image-series.py quay.io/fedora/fedora-coreos \
    --tag-filter '*.*.3.*' --limit 5 --keep-originals \
    --prefix fedora-coreos-test \
    --chunkah-image quay.io/jlebon/chunkah:dev \
        -- --compressed --prune /sysroot/
```

And then to do the actual analysis:

```
tools/analyze-layer-reuse.py localhost/fedora-coreos-test
    --compare-originals

tools/analyze-layer-reuse.py localhost/fedora-coreos-test
    --compare-originals --uncompressed
```

Planning also to analyze Hummingbird images, but images got reset there recently so we lost a lot of a history to make this analysis practical.

Assisted-by: Claude Opus 4.5