### PR TITLE
tools: add FCOS example usage to analysis scripts

### DIFF
--- a/tools/analyze-layer-reuse.py
+++ b/tools/analyze-layer-reuse.py
@@ -1,5 +1,13 @@
 #!/usr/bin/env python3
-"""Compare sequential images and report layer sharing statistics."""
+"""Compare sequential images and report layer sharing statistics.
+
+Example usage for FCOS (after running chunk-image-series.py):
+
+    ./tools/analyze-layer-reuse.py localhost/fedora-coreos-test --compare-originals
+
+This analyzes layer reuse between sequential chunked images and compares
+against the original (un-chunked) images to measure chunking effectiveness.
+"""
 
 import argparse
 import json

--- a/tools/chunk-image-series.py
+++ b/tools/chunk-image-series.py
@@ -1,5 +1,18 @@
 #!/usr/bin/env python3
-"""Pull images from a registry, run chunkah on each, store results."""
+"""Pull images from a registry, run chunkah on each, store results.
+
+Example usage for FCOS:
+
+    ./tools/chunk-image-series.py quay.io/fedora/fedora-coreos \\
+        --tag-filter '*.*.3.*' --limit 5 --keep-originals \\
+        --prefix fedora-coreos-test \\
+        --chunkah-image localhost/chunkah \\
+        -- --compressed --label ostree.commit- --label ostree.final-diffid- --prune /sysroot/
+
+This pulls the 5 most recent stable FCOS images (matching *.*.3.*), runs
+chunkah on each, and stores the results as localhost/fedora-coreos-test:0-4.
+The originals are kept as localhost/fedora-coreos-test-orig:0-4 for comparison.
+"""
 
 import argparse
 import fnmatch


### PR DESCRIPTION
Add example usage in the docstrings for chunk-image-series.py and analyze-layer-reuse.py showing how to use them to analyze FCOS images.

Assisted-by: Claude Opus 4.5