### PR TITLE
ci: test ubi9 and ubi10; follow el9 for MSRV

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,10 +34,23 @@ jobs:
     strategy:
       matrix:
         include:
-          - arch: amd64
+          - name: e2e-tests (fedora, amd64)
             runner: ubuntu-24.04
-          - arch: arm64
+            arch: amd64
+            push: true
+          - name: e2e-tests (fedora, arm64)
             runner: ubuntu-24.04-arm
+            arch: arm64
+            push: true
+          - name: e2e-tests (ubi9)
+            runner: ubuntu-24.04
+            base: registry.access.redhat.com/ubi9/ubi:latest
+            tests: self
+          - name: e2e-tests (ubi10)
+            runner: ubuntu-24.04
+            base: registry.access.redhat.com/ubi10/ubi:latest
+            tests: self
+    name: ${{ matrix.name }}
     permissions:
       contents: read
       packages: write
@@ -50,11 +63,11 @@ jobs:
       - name: Install tools
         run: dnf install -y just buildah podman skopeo jq
       - name: Build image
-        run: just buildimg
+        run: just buildimg -- ${{ matrix.base && format('--build-arg=BASE={0}', matrix.base) || '' }}
       - name: Run tests
-        run: just test
+        run: just test ${{ matrix.tests }}
       - name: Push to ghcr.io
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' && matrix.push
         run: |
           set -euo pipefail
           podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io

--- a/.github/workflows/msrv-bump.yml
+++ b/.github/workflows/msrv-bump.yml
@@ -1,0 +1,59 @@
+name: MSRV Bump
+
+on:
+  schedule:
+    # Weekly on Monday at 9am UTC
+    - cron: '0 9 * * 1'
+  workflow_dispatch: {}
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  check-msrv:
+    runs-on: ubuntu-latest
+    container: registry.access.redhat.com/ubi9/ubi:latest
+    steps:
+      - name: Install tools
+        run: dnf install -y git
+      - name: Configure git
+        run: git config --global --add safe.directory '*'
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Get current MSRV
+        id: current
+        run: |
+          msrv=$(grep '^rust-version' Cargo.toml | sed 's/.*"\(.*\)"/\1/')
+          echo "Current MSRV: ${msrv}"
+          echo "msrv=${msrv}" >> "${GITHUB_OUTPUT}"
+
+      - name: Get RHEL 9 Rust version
+        id: rhel9
+        run: |
+          version=$(dnf repoquery --quiet --latest-limit=1 --qf '%{version}' rust)
+          echo "RHEL 9 Rust version: ${version}"
+          echo "version=${version}" >> "${GITHUB_OUTPUT}"
+
+      - name: Update Cargo.toml
+        if: steps.current.outputs.msrv != steps.rhel9.outputs.version
+        run: |
+          sed -i 's/^rust-version = ".*"/rust-version = "${{ steps.rhel9.outputs.version }}"/' Cargo.toml
+
+      - name: Create pull request
+        if: steps.current.outputs.msrv != steps.rhel9.outputs.version
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: msrv-bump
+          title: "Cargo.toml: bump rust-version to ${{ steps.rhel9.outputs.version }}"
+          body: |
+            RHEL 9 now ships Rust ${{ steps.rhel9.outputs.version }}.
+            Bump the minimum supported Rust version accordingly.
+
+            *This PR was automatically created by the MSRV Bump workflow.*
+          commit-message: |
+            Cargo.toml: bump rust-version to ${{ steps.rhel9.outputs.version }}
+
+            RHEL 9 now ships Rust ${{ steps.rhel9.outputs.version }}.
+            Bump the minimum supported Rust version accordingly.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ authors = ["Jonathan Lebon <jonathan@jlebon.com>"]
 repository = "https://github.com/jlebon/chunkah"
 license = "MIT OR Apache-2.0"
 edition = "2024"
+# Automatically bumped to match RHEL 9; see .github/workflows/msrv-bump.yml
+rust-version = "1.88.0"
 publish = false
 
 [dependencies]

--- a/Containerfile
+++ b/Containerfile
@@ -25,7 +25,15 @@ RUN --mount=type=cache,id=dnf,target=/mnt \
 COPY --from=builder /usr/bin/chunkah /usr/bin/chunkah
 
 FROM rootfs AS rechunk
+ARG DNF_FLAGS
+RUN --mount=type=cache,rw,id=dnf,target=/var/cache/libdnf5 \
+    dnf install ${DNF_FLAGS} sqlite
 COPY --from=rootfs / /rootfs
+RUN for db in /rootfs/var/lib/rpm/rpmdb.sqlite \
+              /rootfs/usr/lib/sysimage/libdnf5/transaction_history.sqlite \
+              /rootfs/var/lib/dnf/history.sqlite; do \
+        if [ -f "${db}" ]; then sqlite3 "${db}" "PRAGMA journal_mode = DELETE;"; fi; \
+    done
 RUN --mount=type=bind,target=/run/src,rw \
     chunkah build --rootfs /rootfs > /run/src/out.ociarchive
 

--- a/Containerfile
+++ b/Containerfile
@@ -3,7 +3,6 @@
 #   buildah build --skip-unused-stages=false -t chunkah .
 
 ARG BASE=quay.io/fedora/fedora-minimal:43
-ARG FINAL_FROM=oci-archive:out.ociarchive
 ARG DNF_FLAGS="-y --setopt=install_weak_deps=False"
 
 FROM ${BASE} AS builder
@@ -23,6 +22,10 @@ RUN --mount=type=cache,id=dnf,target=/mnt \
     cp -a /mnt /var/cache/libdnf5 && \
     dnf install ${DNF_FLAGS} openssl zlib && rm -rf /var/cache/*
 COPY --from=builder /usr/bin/chunkah /usr/bin/chunkah
+# Repeat inline config below for the `--no-chunk` flow. See related XXX below.
+ENTRYPOINT ["/usr/bin/chunkah"]
+ENV CHUNKAH_ROOTFS=/chunkah
+WORKDIR /srv
 
 FROM rootfs AS rechunk
 ARG DNF_FLAGS
@@ -34,10 +37,12 @@ RUN for db in /rootfs/var/lib/rpm/rpmdb.sqlite \
               /rootfs/var/lib/dnf/history.sqlite; do \
         if [ -f "${db}" ]; then sqlite3 "${db}" "PRAGMA journal_mode = DELETE;"; fi; \
     done
+## XXX: Work around https://github.com/containers/buildah/issues/6652 for
+## our own image for now by just passing a config manually rather than using
+## Containerfile directives in the final stage.
 RUN --mount=type=bind,target=/run/src,rw \
-    chunkah build --rootfs /rootfs > /run/src/out.ociarchive
+    chunkah build --rootfs /rootfs \
+        --config-str '{"Config": {"Entrypoint": ["/usr/bin/chunkah"], "Env": ["CHUNKAH_ROOTFS=/chunkah"], "WorkingDir": "/srv"}}' \
+        > /run/src/out.ociarchive
 
-FROM ${FINAL_FROM}
-ENTRYPOINT ["/usr/bin/chunkah"]
-ENV CHUNKAH_ROOTFS=/chunkah
-WORKDIR /srv
+FROM oci-archive:out.ociarchive

--- a/Containerfile
+++ b/Containerfile
@@ -21,7 +21,7 @@ FROM ${BASE} AS rootfs
 ARG DNF_FLAGS
 RUN --mount=type=cache,id=dnf,target=/mnt \
     cp -a /mnt /var/cache/libdnf5 && \
-    dnf install ${DNF_FLAGS} openssl zlib skopeo && rm -rf /var/cache/*
+    dnf install ${DNF_FLAGS} openssl zlib && rm -rf /var/cache/*
 COPY --from=builder /usr/bin/chunkah /usr/bin/chunkah
 
 FROM rootfs AS rechunk

--- a/Justfile
+++ b/Justfile
@@ -41,7 +41,7 @@ checkall: shellcheck check fmt clippy markdownlint versioncheck
 
 # Build chunkah container image (use --no-chunk to skip chunking for faster builds)
 [arg("no_chunk", long="no-chunk", value="true")]
-buildimg no_chunk="":
+buildimg no_chunk="" *ARGS:
     #!/bin/bash
     set -euo pipefail
     buildah="${BUILDAH:-buildah}"
@@ -51,6 +51,7 @@ buildimg no_chunk="":
     if [[ $(echo -e "${version}\n1.44" | sort -V | head -n1) != "1.44" ]]; then
         args+=(-v "$PWD:/run/src" --security-opt=label=disable)
     fi
+    args+=({{ ARGS }})
     echo ${buildah} build "${args[@]}" .
     ${buildah} build "${args[@]}" .
     rm -f out.ociarchive

--- a/Justfile
+++ b/Justfile
@@ -45,7 +45,7 @@ buildimg no_chunk="":
     #!/bin/bash
     set -euo pipefail
     buildah="${BUILDAH:-buildah}"
-    args=(-t chunkah --layers=true {{ if no_chunk == "true" { "--build-arg=FINAL_FROM=rootfs" } else { "--skip-unused-stages=false" } }})
+    args=(-t chunkah --layers=true {{ if no_chunk == "true" { "--target=rootfs" } else { "--skip-unused-stages=false" } }})
     # drop this once we can assume 1.44
     version=$(${buildah} version --json | jq -r '.version')
     if [[ $(echo -e "${version}\n1.44" | sort -V | head -n1) != "1.44" ]]; then

--- a/README.md
+++ b/README.md
@@ -99,13 +99,6 @@ argument.
 > For Buildah versions before v1.44, this also requires `-v $(pwd):/run/src
 > --security-opt=label=disable`.
 
-<!-- markdownlint-disable-next-line MD028 -->
-> [!NOTE]
-> There is [a known bug][buildah-annotations-bug] in this workflow preventing
-> informational layer annotations added by chunkah from persisting to the final
-> image. If you're interested in that information, you must use the `podman
-> load` flow below.
-
 Another option is using the chunkah image directly and image mounts:
 
 ```shell
@@ -167,6 +160,15 @@ ENTRYPOINT ["git"]
 >
 > For Buildah versions before v1.44, this also requires `-v $(pwd):/run/src
 > --security-opt=label=disable`.
+
+<!-- markdownlint-disable-next-line MD028 -->
+> [!NOTE]
+> There is [a known bug][buildah-annotations-bug] in this workflow preventing
+> informational layer annotations added by chunkah from persisting to the
+> final image when additional instructions follow the final `FROM`. If you're
+> interested in that information, you must either use `--config-str` instead
+> to pass your config, or run chunkah as a separate step as described in the
+> previous section.
 
 ## Advanced Usage
 

--- a/tests/e2e/test-self.sh
+++ b/tests/e2e/test-self.sh
@@ -1,0 +1,62 @@
+#!/bin/bash
+# Test the chunkah image itself for proper chunking, catching pathological
+# cases like unclaimed files and misattributed bigfiles.
+set -xeuo pipefail
+shopt -s inherit_errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=SCRIPTDIR/lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+CHUNKED_IMAGE="localhost/chunkah-chunked:test"
+
+cleanup() {
+    cleanup_images "${CHUNKED_IMAGE}"
+}
+trap cleanup EXIT
+
+# Check if the image is already chunked by looking for chunkah authorship in the
+# image history entries.
+is_chunked=$(skopeo inspect --config "containers-storage:${CHUNKAH_IMG:?}" | \
+    jq '[.history[]? | select(.author == "chunkah")] | length > 0')
+
+if [[ "${is_chunked}" == "true" ]]; then
+    podman tag "${CHUNKAH_IMG}" "${CHUNKED_IMAGE}"
+else
+    # chunk it using Containerfile.splitter
+    config_str=$(podman inspect "${CHUNKAH_IMG}")
+    buildah_build \
+        --from "${CHUNKAH_IMG}" --build-arg CHUNKAH="${CHUNKAH_IMG}" \
+        --build-arg CHUNKAH_CONFIG_STR="${config_str}" \
+        --build-arg CHUNKAH_ARGS="-v" \
+        -t "${CHUNKED_IMAGE}" "${REPO_ROOT}/Containerfile.splitter"
+fi
+
+# verify minimum layer count
+layer_count=$(skopeo inspect "containers-storage:${CHUNKED_IMAGE}" | jq '.LayersData | length')
+if [[ ${layer_count} -lt 32 ]]; then
+    echo "ERROR: Expected at least 32 layers, got ${layer_count} in ${CHUNKED_IMAGE}"
+    exit 1
+fi
+
+# check for expected RPM components
+assert_has_components "${CHUNKED_IMAGE}" "rpm/glibc" "rpm/openssl"
+
+# Verify no unexpected bigfiles; any not in the allowlist (e.g. libc.so.6,
+# libcrypto.so) would indicate RPM database read failures; this was a bug early
+# on when testing against UBI10 due to PQC RPM signatures.
+annotations=$(get_layer_annotations "${CHUNKED_IMAGE}")
+bigfiles=$(grep '^bigfiles/' <<< "${annotations}")
+while IFS= read -r component; do
+    case "${component}" in
+        ""|bigfiles/chunkah|bigfiles/rpmdb.sqlite) continue;;
+        *) echo "ERROR: Unexpected bigfile '${component}' in ${CHUNKED_IMAGE}"; exit 1;;
+    esac
+done <<< "${bigfiles}"
+
+# verify the unclaimed layer is small (< 1 MiB)
+unclaimed_size=$(skopeo inspect "containers-storage:${CHUNKED_IMAGE}" | \
+    jq '.LayersData[] | select(.Annotations["org.chunkah.component"] | contains("chunkah/unclaimed")) | .Size')
+[[ -n "${unclaimed_size}" ]]
+[[ ${unclaimed_size} -le 1048576 ]]


### PR DESCRIPTION
Define a minimum supported Rust version matching what RHEL 9 ships to
ensure chunkah builds on that platform. Add a weekly scheduled workflow
that checks for Rust version updates in UBI9 repos and opens a PR to
bump the MSRV accordingly.

Build and test chunkah on UBI 9 and UBI 10. We don't run the full
testsuite, just the self-test.

Assisted-by: Claude Opus 4.6