### PR TITLE
tree: fix various reproducibility issues and add e2e test

### DIFF
--- a/src/cmd_build.rs
+++ b/src/cmd_build.rs
@@ -335,6 +335,8 @@ fn pack_components(
     let max_layers = args.max_layers;
 
     let mut entries: Vec<Option<(String, Component)>> = components.into_iter().map(Some).collect();
+    // sort by component name for deterministic inputs to the packing algorithm
+    entries.sort_by(|a, b| a.as_ref().unwrap().0.cmp(&b.as_ref().unwrap().0));
 
     let items: Vec<PackItem> = entries
         .iter()
@@ -374,6 +376,8 @@ fn pack_components(
                 merged_files.extend(comp.files);
             }
 
+            // this becomes history/annotation values; sort for reproducibility
+            names.sort();
             let merged_name = names.join(" ");
             result.push((
                 merged_name,

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -120,7 +120,9 @@ impl ComponentsRepos {
             repos.push(Box::new(repo));
         }
 
-        if let Some(repo) = rpm::RpmRepo::load(rootfs, files).context("loading rpmdb")? {
+        if let Some(repo) =
+            rpm::RpmRepo::load(rootfs, files, default_mtime_clamp).context("loading rpmdb")?
+        {
             repos.push(Box::new(repo));
         }
 
@@ -306,7 +308,11 @@ mod tests {
 
         let xattr_repo = xattr::XattrRepo::load(&files, 0).unwrap().unwrap();
         let packages = rpm_qa::load_from_str(RPM_FIXTURE).unwrap();
-        let rpm_repo = rpm::RpmRepo::load_from_packages(packages).unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs();
+        let rpm_repo = rpm::RpmRepo::load_from_packages(packages, now).unwrap();
 
         let repos: Vec<Box<dyn ComponentsRepo>> = vec![Box::new(rpm_repo), Box::new(xattr_repo)];
         let loaded = ComponentsRepos {

--- a/tests/e2e/test-reproducibility.sh
+++ b/tests/e2e/test-reproducibility.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+# Test that chunked images are reproducible when built with SOURCE_DATE_EPOCH.
+set -xeuo pipefail
+shopt -s inherit_errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=SCRIPTDIR/lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+SOURCE_IMAGE="quay.io/fedora/fedora-minimal:latest"
+
+cleanup() {
+    cleanup_images "${SOURCE_IMAGE}"
+}
+trap cleanup EXIT
+
+podman pull "${SOURCE_IMAGE}"
+CHUNKAH_CONFIG_STR=$(podman inspect "${SOURCE_IMAGE}")
+
+# run chunkah twice on the same rootfs with a fixed SOURCE_DATE_EPOCH
+for i in 1 2; do
+    podman run --rm --mount=type=image,src="${SOURCE_IMAGE}",target=/chunkah \
+        -e CHUNKAH_CONFIG_STR="${CHUNKAH_CONFIG_STR}" \
+        -e SOURCE_DATE_EPOCH=1700000000 \
+            "${CHUNKAH_IMG:?}" build > "out${i}.ociarchive"
+done
+
+# the two OCI archives should be byte-identical
+sha1=$(sha256sum out1.ociarchive | cut -d' ' -f1)
+sha2=$(sha256sum out2.ociarchive | cut -d' ' -f1)
+if [[ "${sha1}" != "${sha2}" ]]; then
+    echo "ERROR: OCI archives differ between builds"
+    echo "Build 1: ${sha1}"
+    echo "Build 2: ${sha2}"
+    if command -v diffoscope &>/dev/null; then
+        diffoscope out1.ociarchive out2.ociarchive || true
+    fi
+    exit 1
+fi


### PR DESCRIPTION
Fix three sources of non-determinism that prevented chunkah from producing reproducible OCI images across runs:
1. the way we calculated the clamp time for RPM components wasn't accounting for subpackages of a same SRPM having different build times
2. when calculating stability, we were using the current time to define the lookback period; pass through the default clamp time (which is derived from `SOURCE_DATE_EPOCH` if defined) and use that instead
3. when packing, we weren't providing deterministic input to the algorithm, so results may vary very slightly
4. when reconstructing merged components, we need to ensure their names are deterministic as well

Add an e2e test that builds the same image twice with `SOURCE_DATE_EPOCH` and verifies the OCI archives are byte-identical.

Closes #18

Assisted-by: Claude Opus 4.6
