### PR TITLE
tree: add logging using `tracing` crate

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -115,6 +115,36 @@ Each group is sorted alphabetically. `cargo fmt` handles this.
 - Default `rustfmt` and `clippy` settings; all clippy warnings are errors
   (`-D warnings`).
 
+#### Logging
+
+Uses `tracing` crate. Log levels:
+
+- **trace**: Per-item iteration details (e.g., each file scanned, each path
+  claimed). Very verbose.
+- **debug**: Flow of control, configuration values, state changes. Useful for
+  diagnosing issues.
+- **info**: Significant milestones (e.g., "scan complete", "build complete").
+  Visible by default.
+- **warn**: Unexpected but recoverable conditions (e.g., missing package
+  metadata).
+- **error**: Unused. We propagate errors up.
+
+Syntax:
+
+```rust
+tracing::info!(files = files.len(), "scan complete");
+tracing::debug!(path = %path, "canonicalized");  // %path uses Display
+tracing::trace!(path = %path, "scanned file");
+tracing::warn!(package = %name, "missing sourcerpm");
+```
+
+Guidelines:
+
+- Messages are lowercase, no trailing punctuation.
+- Use `%` prefix for `Display` formatting (cleaner output for paths).
+- Use `?` prefix for `Debug` formatting (when needed).
+- Default level is `info`; use `-v` for debug, `-vv` for trace.
+
 ### Bash
 
 Script header (required):

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,6 +11,8 @@ are created to maximize layer reuse rather than reflecting Dockerfile structure.
 
 ## Build and Test Commands
 
+The justfile is called `Justfile` (capitalized), not `justfile`.
+
 ```bash
 just build               # Build the project (dev)
 just build release       # Build the project (release)

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -205,6 +205,8 @@ dependencies = [
  "serde_json",
  "tar",
  "tempfile",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -584,6 +586,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "lazy_static"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+
+[[package]]
 name = "libc"
 version = "0.2.180"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -630,6 +638,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
+name = "matchers"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+dependencies = [
+ "regex-automata",
+]
+
+[[package]]
 name = "maybe-owned"
 version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -661,6 +678,15 @@ dependencies = [
  "cfg-if",
  "cfg_aliases",
  "libc",
+]
+
+[[package]]
+name = "nu-ansi-term"
+version = "0.50.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -767,6 +793,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
 
 [[package]]
 name = "pkg-config"
@@ -984,6 +1016,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "sharded-slab"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -994,6 +1035,12 @@ name = "simd-adler32"
 version = "0.3.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+
+[[package]]
+name = "smallvec"
+version = "1.15.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "strsim"
@@ -1075,6 +1122,76 @@ dependencies = [
 ]
 
 [[package]]
+name = "thread_local"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
+name = "tracing"
+version = "0.1.44"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+dependencies = [
+ "pin-project-lite",
+ "tracing-attributes",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.36"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+dependencies = [
+ "once_cell",
+ "valuable",
+]
+
+[[package]]
+name = "tracing-log"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
+dependencies = [
+ "log",
+ "once_cell",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+dependencies = [
+ "matchers",
+ "nu-ansi-term",
+ "once_cell",
+ "regex-automata",
+ "sharded-slab",
+ "smallvec",
+ "thread_local",
+ "tracing",
+ "tracing-core",
+ "tracing-log",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1096,6 +1213,12 @@ dependencies = [
  "js-sys",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "valuable"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba73ea9cf16a25df0c8caa16c51acb937d5712a8429db78a3ee29d5dcacd3a65"
 
 [[package]]
 name = "vcpkg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ rpm-qa = "0.1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tar = "0.4"
+tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 fs-set-times = "0.20.3"

--- a/Justfile
+++ b/Justfile
@@ -78,7 +78,7 @@ diff +ARGS:
     args=({{ ARGS }})
     image1="${args[0]}"
     image2="${args[1]}"
-    podman run --rm \
+    podman run --rm -v /var/tmp \
         --mount=type=image,src="${image1}",target=/image1 \
         --mount=type=image,src="${image2}",target=/image2 \
         "${img}" /image1 /image2 "${args[@]:2}"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ with content-based layers.
   - [Building from a raw rootfs](#building-from-a-raw-rootfs)
   - [Customizing the OCI image config and annotations](#customizing-the-oci-image-config-and-annotations)
   - [Compatibility with bootable (bootc) images](#compatibility-with-bootable-bootc-images)
+  - [Debugging](#debugging)
 - [Relationship to `zstd:chunked`](#relationship-to-zstdchunked)
 - [Origins](#origins)
 
@@ -241,6 +242,13 @@ for better splitting.
 
 OSTree-based images as created by `rpm-ostree` and `ostree container
 encapsulate` are not supported.
+
+### Debugging
+
+Use `-v` for verbose output or the `RUST_LOG` environment variable for
+fine-grained control (e.g. `RUST_LOG=chunkah=debug`). Logs are written
+to stderr. (There is also `-vv` for trace output mostly meant for chunkah
+development. You'll want to redirect stderr to a file!)
 
 ## Relationship to `zstd:chunked`
 

--- a/src/components/bigfiles.rs
+++ b/src/components/bigfiles.rs
@@ -79,6 +79,7 @@ impl BigfilesRepo {
 
             // create a component for this path
             let (idx, _) = components.insert_full(component_name);
+            tracing::trace!(path = %path, component = %components[idx], id = idx, "bigfile component created");
             let component_id = ComponentId(idx);
             path_to_component.insert(path.clone(), component_id);
 
@@ -93,6 +94,12 @@ impl BigfilesRepo {
         if components.is_empty() {
             return None;
         }
+
+        tracing::debug!(
+            components = components.len(),
+            paths = path_to_component.len(),
+            "loaded bigfiles components"
+        );
 
         Some(Self {
             components,

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,11 +9,16 @@ mod utils;
 
 use anyhow::{Context, Result};
 use clap::{Parser, Subcommand};
+use tracing_subscriber::{EnvFilter, fmt};
 
 #[derive(Parser)]
 #[command(name = "chunkah")]
 #[command(about = "A generalized container image rechunker")]
 struct Cli {
+    /// Increase verbosity (-v for debug, -vv for trace)
+    #[arg(short, long, action = clap::ArgAction::Count, global = true)]
+    verbose: u8,
+
     #[command(subcommand)]
     command: Command,
 }
@@ -25,17 +30,37 @@ enum Command {
 }
 
 fn main() -> Result<()> {
+    let cli = Cli::parse();
+
+    init_tracing(cli.verbose);
+    tracing::debug!(version = env!("CARGO_PKG_VERSION"), "starting chunkah");
+
     // Set up a SIGINT handler that terminates the process. This is needed
     // because chunkah may run as PID 1 in a container, which can only receive
     // signals it has explicit handlers for. This avoids users having to add
     // e.g. --init to get Ctrl-C to behave as expected.
     ctrlc::set_handler(|| std::process::exit(130)).context("setting up signal handler")?;
 
-    let cli = Cli::parse();
-
     match cli.command {
         Command::Build(args) => cmd_build::run(&args)?,
     }
 
     Ok(())
+}
+
+fn init_tracing(verbose: u8) {
+    let format = fmt::format().without_time().with_target(false).compact();
+
+    // CLI -v flags take precedence, then RUST_LOG, then default to info
+    let env_filter = match verbose {
+        0 => EnvFilter::try_from_default_env().unwrap_or_else(|_| EnvFilter::new("chunkah=info")),
+        1 => EnvFilter::new("chunkah=debug"),
+        _ => EnvFilter::new("chunkah=trace"),
+    };
+
+    tracing_subscriber::fmt()
+        .event_format(format)
+        .with_writer(std::io::stderr)
+        .with_env_filter(env_filter)
+        .init();
 }

--- a/tests/e2e/test-buildtime-options.sh
+++ b/tests/e2e/test-buildtime-options.sh
@@ -26,7 +26,7 @@ RUN mkdir -p /prune-children/nested && echo "should be gone" > /prune-children/n
 FROM ${CHUNKAH_IMG:?} AS chunkah
 RUN --mount=from=builder,src=/,target=/chunkah,ro \\
     --mount=type=bind,target=/run/src,rw \\
-        chunkah build \\
+        chunkah build -v \\
             --skip-special-files \\
             --prune /prune-me \\
             --prune /prune-children/ \\

--- a/tests/e2e/test-buildtime.sh
+++ b/tests/e2e/test-buildtime.sh
@@ -26,7 +26,7 @@ RUN cp /usr/bin/true /usr/bin/test-caps && setcap cap_net_raw+ep /usr/bin/test-c
 FROM ${CHUNKAH_IMG:?} AS chunkah
 RUN --mount=from=builder,src=/,target=/chunkah,ro \\
     --mount=type=bind,target=/run/src,rw \\
-        chunkah build > /run/src/out.ociarchive
+        chunkah build -v > /run/src/out.ociarchive
 
 FROM oci-archive:out.ociarchive
 EOF

--- a/tests/e2e/test-existing-build.sh
+++ b/tests/e2e/test-existing-build.sh
@@ -22,6 +22,7 @@ config_str=$(podman inspect "${TARGET_IMAGE}")
 buildah_build \
     --from "${TARGET_IMAGE}" --build-arg CHUNKAH="${CHUNKAH_IMG:?}" \
     --build-arg CHUNKAH_CONFIG_STR="${config_str}" \
+    --build-arg CHUNKAH_ARGS="-v" \
     -t "${CHUNKED_IMAGE}" "${REPO_ROOT}/Containerfile.splitter"
 
 # sanity-check it

--- a/tests/e2e/test-existing-run.sh
+++ b/tests/e2e/test-existing-run.sh
@@ -21,7 +21,7 @@ CHUNKAH_CONFIG_STR=$(podman inspect "${SOURCE_IMAGE}")
 # run chunkah!
 podman run --rm --mount=type=image,src="${SOURCE_IMAGE}",target=/chunkah \
   -e CHUNKAH_CONFIG_STR="${CHUNKAH_CONFIG_STR}" \
-      "${CHUNKAH_IMG:?}" build > out.ociarchive
+      "${CHUNKAH_IMG:?}" build -v > out.ociarchive
 
 # XXX: need to fix 'podman load' to only print image ID on its stdout, like 'podman pull'
 iid=$(podman load -i out.ociarchive)

--- a/tests/e2e/test-fcos.sh
+++ b/tests/e2e/test-fcos.sh
@@ -23,7 +23,7 @@ config_str=$(podman inspect "${TARGET_IMAGE}")
 buildah_build \
     --from "${TARGET_IMAGE}" --build-arg CHUNKAH="${CHUNKAH_IMG:?}" \
     --build-arg CHUNKAH_CONFIG_STR="${config_str}" \
-    --build-arg "CHUNKAH_ARGS=--prune /sysroot/ --max-layers 96" \
+    --build-arg "CHUNKAH_ARGS=-v --prune /sysroot/ --max-layers 96" \
     -t "${CHUNKED_IMAGE}" "${REPO_ROOT}/Containerfile.splitter"
 
 # sanity-check it

--- a/tests/e2e/test-reproducibility.sh
+++ b/tests/e2e/test-reproducibility.sh
@@ -22,7 +22,7 @@ for i in 1 2; do
     podman run --rm --mount=type=image,src="${SOURCE_IMAGE}",target=/chunkah \
         -e CHUNKAH_CONFIG_STR="${CHUNKAH_CONFIG_STR}" \
         -e SOURCE_DATE_EPOCH=1700000000 \
-            "${CHUNKAH_IMG:?}" build > "out${i}.ociarchive"
+            "${CHUNKAH_IMG:?}" build -v > "out${i}.ociarchive"
 done
 
 # the two OCI archives should be byte-identical


### PR DESCRIPTION
One thing sorely missing right now is any feedback of what chunkah is doing.

This remedies the situation quite a bit by hooking up the tracing crate and adding logging throughout the codebase. I might've went overboard with the trace level, though it's really nice to be able to follow exactly the data flow for any given path, from scanning, claiming,
packing, merging, and serializing to tar.

Change all our e2e tests to use the debug level.

Assisted-by: Claude Opus 4.5

Closes: https://github.com/coreos/chunkah/issues/17
