### PR TITLE
scan: sort xattrs for reproducibility

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -53,6 +53,7 @@ buildimg no_chunk="":
     fi
     echo ${buildah} build "${args[@]}" .
     ${buildah} build "${args[@]}" .
+    rm -f out.ociarchive
 
 # Run end-to-end tests with built chunkah image
 test *ARGS:
@@ -101,6 +102,7 @@ split IMG *ARGS:
         args+=(-v "$PWD:/run/src" --security-opt=label=disable)
     fi
     ${buildah} build "${args[@]}" Containerfile.splitter
+    rm -f out.ociarchive
 
 # Cut a release (use --no-push to prepare without pushing)
 release *ARGS:

--- a/src/scan.rs
+++ b/src/scan.rs
@@ -157,6 +157,11 @@ pub fn read_xattrs(rootfs: &Dir, fs_path: &str) -> anyhow::Result<Vec<(String, V
         }
     }
 
+    // Sort by key to ensure deterministic ordering. llistxattr(2) does not
+    // guarantee any particular order, and the order can vary between runs
+    // depending on filesystem internals.
+    xattrs.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+
     Ok(xattrs)
 }
 

--- a/tests/e2e/lib.sh
+++ b/tests/e2e/lib.sh
@@ -13,6 +13,7 @@ buildah_build() {
         tmp_args+=(-v "${PWD}:/run/src" --security-opt=label=disable)
     fi
     ${BUILDAH:-buildah} build --skip-unused-stages=false "${tmp_args[@]}" "$@"
+    rm -f "${PWD}/out.ociarchive"
 }
 
 # Get layer annotations for an image.

--- a/tests/e2e/test-buildtime.sh
+++ b/tests/e2e/test-buildtime.sh
@@ -8,24 +8,40 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 . "${SCRIPT_DIR}/lib.sh"
 
 BASE_IMAGE="quay.io/fedora/fedora-minimal:latest"
+ROOTFS_IMAGE="localhost/test-buildtime-rootfs:latest"
 CHUNKED_IMAGE="localhost/fedora-minimal-chunked:test"
+CHUNKED_IMAGE2="localhost/fedora-minimal-chunked:test2"
 
 cleanup() {
-    cleanup_images "${CHUNKED_IMAGE}"
+    cleanup_images "${CHUNKED_IMAGE}" "${CHUNKED_IMAGE2}" "${ROOTFS_IMAGE}"
 }
 trap cleanup EXIT
 
 podman pull "${BASE_IMAGE}"
 
+# Build rootfs as a separate image so that the reproducibility check below
+# operates on the same rootfs both times. Without this, each buildah_build
+# would re-run dnf install, producing different file timestamps.
+cat > Containerfile.rootfs <<EOF
+FROM ${BASE_IMAGE}
+RUN dnf install -y jq acl attr && dnf clean all
+EOF
+buildah build -t "${ROOTFS_IMAGE}" -f Containerfile.rootfs .
+
+# build chunked image using FROM oci-archive: trick
 cat > Containerfile <<EOF
-FROM ${BASE_IMAGE} AS builder
-RUN microdnf install -y jq && microdnf clean all
-# create a test binary and set a capability on it
-RUN cp /usr/bin/true /usr/bin/test-caps && setcap cap_net_raw+ep /usr/bin/test-caps
+FROM ${ROOTFS_IMAGE} AS builder
+# create a test binary with various xattr types
+RUN cp /usr/bin/true /usr/bin/test-xattrs && \
+    setcap cap_net_raw+ep /usr/bin/test-xattrs && \
+    setfacl -m u:nobody:r /usr/bin/test-xattrs && \
+    setfattr -n user.testkey1 -v testvalue1 /usr/bin/test-xattrs && \
+    setfattr -n user.testkey2 -v testvalue2 /usr/bin/test-xattrs
 
 FROM ${CHUNKAH_IMG:?} AS chunkah
 RUN --mount=from=builder,src=/,target=/chunkah,ro \\
     --mount=type=bind,target=/run/src,rw \\
+    SOURCE_DATE_EPOCH=1700000000 \\
         chunkah build -v > /run/src/out.ociarchive
 
 FROM oci-archive:out.ociarchive
@@ -43,5 +59,31 @@ assert_has_components "${CHUNKED_IMAGE}" "rpm/filesystem" "rpm/setup" "rpm/glibc
 assert_layer_count "${CHUNKED_IMAGE}" 64
 
 # verify that security.capability xattrs are preserved
-caps=$(podman run --rm "${CHUNKED_IMAGE}" getcap /usr/bin/test-caps)
+caps=$(podman run --rm "${CHUNKED_IMAGE}" getcap /usr/bin/test-xattrs)
 [[ "${caps}" == *"cap_net_raw=ep"* ]]
+
+# verify that POSIX ACLs (system.posix_acl_access) are preserved
+acl=$(podman run --rm "${CHUNKED_IMAGE}" getfacl -c /usr/bin/test-xattrs)
+[[ "${acl}" == *"user:nobody:r--"* ]]
+
+# verify that user.* xattrs are preserved
+xattr1=$(podman run --rm "${CHUNKED_IMAGE}" getfattr -n user.testkey1 --only-values /usr/bin/test-xattrs)
+[[ "${xattr1}" == "testvalue1" ]]
+xattr2=$(podman run --rm "${CHUNKED_IMAGE}" getfattr -n user.testkey2 --only-values /usr/bin/test-xattrs)
+[[ "${xattr2}" == "testvalue2" ]]
+
+# verify reproducibility: build again with --no-cache to force chunkah to
+# re-run on the same rootfs and compare image IDs; this validates that xattr
+# sorting and trusted.* filtering produce deterministic output
+buildah_build --no-cache -t "${CHUNKED_IMAGE2}" -f Containerfile .
+
+id1=$(podman inspect --format '{{.Id}}' "${CHUNKED_IMAGE}")
+id2=$(podman inspect --format '{{.Id}}' "${CHUNKED_IMAGE2}")
+if [[ "${id1}" != "${id2}" ]]; then
+    echo "ERROR: image IDs differ between builds"
+    echo "Build 1: ${id1}"
+    echo "Build 2: ${id2}"
+    # this will fail; it's just a way to call into `just diff` to print the diff
+    assert_no_diff "${CHUNKED_IMAGE}" "${CHUNKED_IMAGE2}"
+    exit 1 # but just in case
+fi


### PR DESCRIPTION
Yet another source of reproducibility issues. If a file has multiple
xattrs, the order in which we read them in may change, but serializing
them to the tar layer needs to be deterministic.

Sort them at scan time.

Extend the buildtime e2e test to try to cover this by adding more
xattrs (including ACLs which we didn't have any coverage for before).
Though it's not easy to really test this without injecting our own
llistxattr(2).

Assisted-by: Claude Opus 4.6