### PR TITLE
tree: add size information when logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.opencode/plans
 /target
+__pycache__/

--- a/src/cmd_build.rs
+++ b/src/cmd_build.rs
@@ -191,7 +191,8 @@ pub fn run(args: &BuildArgs) -> Result<()> {
         .prune(&args.prune)?
         .scan()
         .with_context(|| format!("scanning {} for files", args.rootfs))?;
-    tracing::info!(files = files.len(), "scan complete");
+    let total_size: u64 = files.values().map(|f| f.size).sum();
+    tracing::info!(files = files.len(), size = %utils::format_size(total_size), "scan complete");
 
     let repos =
         ComponentsRepos::load(&rootfs, &files, created_epoch).context("loading components")?;

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -9,6 +9,24 @@ pub fn get_current_epoch() -> Result<u64> {
         .map(|d| d.as_secs())
 }
 
+/// Format a byte count as a human-readable string using binary units.
+pub fn format_size(bytes: u64) -> String {
+    const KIB: f64 = 1024.0;
+    const MIB: f64 = 1024.0 * KIB;
+    const GIB: f64 = 1024.0 * MIB;
+
+    let bytes_f = bytes as f64;
+    if bytes_f >= GIB {
+        format!("{:.1} GiB", bytes_f / GIB)
+    } else if bytes_f >= MIB {
+        format!("{:.1} MiB", bytes_f / MIB)
+    } else if bytes_f >= KIB {
+        format!("{:.1} KiB", bytes_f / KIB)
+    } else {
+        format!("{} B", bytes)
+    }
+}
+
 /// Returns the OCI/Go architecture string.
 ///
 /// If `arch` is provided, translates it to OCI format.
@@ -25,6 +43,18 @@ pub fn get_goarch(arch: Option<&str>) -> &str {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn test_format_size() {
+        assert_eq!(format_size(0), "0 B");
+        assert_eq!(format_size(512), "512 B");
+        assert_eq!(format_size(1023), "1023 B");
+        assert_eq!(format_size(1024), "1.0 KiB");
+        assert_eq!(format_size(1536), "1.5 KiB");
+        assert_eq!(format_size(1048576), "1.0 MiB");
+        assert_eq!(format_size(1073741824), "1.0 GiB");
+        assert_eq!(format_size(1610612736), "1.5 GiB");
+    }
 
     #[test]
     fn test_get_goarch() {


### PR DESCRIPTION
It's informative to see how large an image is, and the repartition of
the data across the different repos. This could also help catch issues
early on when the expected repartition doesn't match what one would
expect.

Assisted-by: Claude Opus 4.6