### PR TITLE
build: use image Created timestamp as source date epoch fallback

### DIFF
--- a/tests/e2e/test-reproducibility.sh
+++ b/tests/e2e/test-reproducibility.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-# Test that chunked images are reproducible when built with SOURCE_DATE_EPOCH.
+# Test that chunked images are reproducible.
 set -xeuo pipefail
 shopt -s inherit_errexit
 
@@ -17,23 +17,34 @@ trap cleanup EXIT
 podman pull "${SOURCE_IMAGE}"
 CHUNKAH_CONFIG_STR=$(podman inspect "${SOURCE_IMAGE}")
 
-# run chunkah twice on the same rootfs with a fixed SOURCE_DATE_EPOCH
+assert_archives_identical() {
+    local sum1 sum2
+    sum1=$(sha256sum out1.ociarchive | cut -d' ' -f1)
+    sum2=$(sha256sum out2.ociarchive | cut -d' ' -f1)
+    if [[ "${sum1}" != "${sum2}" ]]; then
+        echo "ERROR: OCI archives differ between builds"
+        echo "Build 1: ${sum1}"
+        echo "Build 2: ${sum2}"
+        if command -v diffoscope &>/dev/null; then
+            diffoscope out1.ociarchive out2.ociarchive || true
+        fi
+        exit 1
+    fi
+}
+
+# Test 1: reproducible with explicit SOURCE_DATE_EPOCH
 for i in 1 2; do
     podman run --rm --mount=type=image,src="${SOURCE_IMAGE}",target=/chunkah \
         -e CHUNKAH_CONFIG_STR="${CHUNKAH_CONFIG_STR}" \
         -e SOURCE_DATE_EPOCH=1700000000 \
             "${CHUNKAH_IMG:?}" build -v > "out${i}.ociarchive"
 done
+assert_archives_identical
 
-# the two OCI archives should be byte-identical
-sha1=$(sha256sum out1.ociarchive | cut -d' ' -f1)
-sha2=$(sha256sum out2.ociarchive | cut -d' ' -f1)
-if [[ "${sha1}" != "${sha2}" ]]; then
-    echo "ERROR: OCI archives differ between builds"
-    echo "Build 1: ${sha1}"
-    echo "Build 2: ${sha2}"
-    if command -v diffoscope &>/dev/null; then
-        diffoscope out1.ociarchive out2.ociarchive || true
-    fi
-    exit 1
-fi
+# Test 2: reproducible without SOURCE_DATE_EPOCH (uses image's Created timestamp)
+for i in 1 2; do
+    podman run --rm --mount=type=image,src="${SOURCE_IMAGE}",target=/chunkah \
+        -e CHUNKAH_CONFIG_STR="${CHUNKAH_CONFIG_STR}" \
+            "${CHUNKAH_IMG:?}" build -v > "out${i}.ociarchive"
+done
+assert_archives_identical


### PR DESCRIPTION
When splitting an existing image and no SOURCE_DATE_EPOCH is provided, use the Created timestamp from the image inspect output instead of the current time. This makes re-splitting an existing image reproducible without requiring the caller to explicitly set SOURCE_DATE_EPOCH.

Assisted-by: Claude Opus 4.6