### PR TITLE
build: use threads to speed up tar layer creation

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,16 +4,18 @@
 
 ARG BASE=quay.io/fedora/fedora-minimal:43
 ARG DNF_FLAGS="-y --setopt=install_weak_deps=False"
+ARG CACHE_ID=chunkah-target
 
 FROM ${BASE} AS builder
 ARG DNF_FLAGS
+ARG CACHE_ID
 RUN --mount=type=cache,rw,id=dnf,target=/var/cache/libdnf5 \
     dnf install ${DNF_FLAGS} cargo rust pkg-config openssl-devel zlib-devel
 WORKDIR /build
 COPY Cargo.toml Cargo.lock ./
 COPY src ./src
 RUN --mount=type=cache,rw,id=cargo,target=/root/.cargo \
-    --mount=type=cache,rw,id=target,target=/build/target \
+    --mount=type=cache,rw,id=${CACHE_ID},target=/build/target \
     cargo build --release && cp /build/target/release/chunkah /usr/bin
 
 FROM ${BASE} AS rootfs

--- a/Justfile
+++ b/Justfile
@@ -46,6 +46,8 @@ buildimg no_chunk="" *ARGS:
     set -euo pipefail
     buildah="${BUILDAH:-buildah}"
     args=(-t chunkah --layers=true {{ if no_chunk == "true" { "--target=rootfs" } else { "--skip-unused-stages=false" } }})
+    cache_id=$(realpath "$PWD" | sha256sum | cut -f1 -d' ')
+    args+=(--build-arg CACHE_ID=chunkah-target-${cache_id})
     # drop this once we can assume 1.44
     version=$(${buildah} version --json | jq -r '.version')
     if [[ $(echo -e "${version}\n1.44" | sort -V | head -n1) != "1.44" ]]; then

--- a/src/cmd_build.rs
+++ b/src/cmd_build.rs
@@ -1,4 +1,5 @@
 use std::collections::HashMap;
+use std::num::NonZeroUsize;
 
 use anyhow::{Context, Result};
 use camino::Utf8PathBuf;
@@ -103,6 +104,10 @@ pub struct BuildArgs {
     /// absolute.
     #[arg(long = "prune", value_name = "PATH")]
     prune: Vec<Utf8PathBuf>,
+
+    /// Number of threads for parallel layer writing (0 = auto-detect)
+    #[arg(short = 'T', long, default_value_t = 0, env = "CHUNKAH_THREADS")]
+    threads: usize,
 
     /// Write peak memory usage (in bytes) to a file
     #[arg(long, value_name = "PATH", hide = true)]
@@ -216,9 +221,20 @@ pub fn run(args: &BuildArgs) -> Result<()> {
         Compression::None
     };
 
+    let threads = NonZeroUsize::new(args.threads).unwrap_or_else(|| {
+        match std::thread::available_parallelism() {
+            Ok(n) => n,
+            Err(e) => {
+                tracing::warn!(err = %e, "failed to detect available parallelism, defaulting to 1");
+                NonZeroUsize::MIN
+            }
+        }
+    });
+
     let builder = Builder::new(&rootfs, components)
         .context("creating builder")?
         .compression(compression)
+        .threads(threads)
         .annotations(annotations)
         .config(image_config);
 

--- a/src/ocibuilder.rs
+++ b/src/ocibuilder.rs
@@ -1,5 +1,7 @@
 use std::collections::HashMap;
 use std::io::Write;
+use std::num::NonZeroUsize;
+use std::sync::atomic::{AtomicUsize, Ordering};
 
 use anyhow::{Context, Result};
 use cap_std_ext::cap_std::fs::Dir;
@@ -27,10 +29,19 @@ pub struct Builder {
     components: Vec<(String, Component)>,
     /// Compression settings for layers and archive.
     compression: Compression,
+    /// Number of threads for parallel layer writing.
+    threads: NonZeroUsize,
     /// Annotations to add to the image manifest.
     annotations: Option<HashMap<String, String>>,
     /// The image configuration.
     config: Option<oci_image::ImageConfiguration>,
+}
+
+/// Result of writing a single component's tar layer.
+struct ComponentLayer {
+    layer: ocidir::Layer,
+    annotations: HashMap<String, String>,
+    history: oci_image::History,
 }
 
 impl Builder {
@@ -44,6 +55,7 @@ impl Builder {
             oci_dir,
             components,
             compression: Compression::default(),
+            threads: NonZeroUsize::MIN,
             annotations: None,
             config: None,
         })
@@ -52,6 +64,12 @@ impl Builder {
     /// Set the compression settings.
     pub fn compression(mut self, compression: Compression) -> Self {
         self.compression = compression;
+        self
+    }
+
+    /// Set the number of threads for parallel layer writing.
+    pub fn threads(mut self, threads: NonZeroUsize) -> Self {
+        self.threads = threads;
         self
     }
 
@@ -123,35 +141,90 @@ impl Builder {
         Ok(())
     }
 
-    /// Add layers to the OCI directory and update the manifest and config.
+    /// Write layers to the OCI directory in parallel and update the manifest and config.
     fn add_components(
         &self,
         manifest: &mut oci_image::ImageManifest,
         config: &mut oci_image::ImageConfiguration,
     ) -> Result<()> {
-        for (name, component) in &self.components {
-            if component.files.is_empty() {
-                tracing::debug!(component = %name, "skipping empty component");
-                continue;
-            }
-            self.add_component(manifest, config, name, component)
-                .with_context(|| format!("adding component {}", name))?;
+        // filter out empty components
+        let components: Vec<_> = self
+            .components
+            .iter()
+            .filter(|(name, component)| {
+                if component.files.is_empty() {
+                    tracing::debug!(component = %name, "skipping empty component");
+                    false
+                } else {
+                    true
+                }
+            })
+            .collect();
+
+        let num_workers = self.threads.get().min(components.len());
+        tracing::info!(
+            threads = num_workers,
+            layers = components.len(),
+            "writing layers"
+        );
+
+        // farm out to worker threads; they each keep picking the next component
+        // (by index) to work on until there are none and return a Vec of the results
+        let next_i = AtomicUsize::new(0);
+        let mut results: Vec<(usize, Result<ComponentLayer>)> = std::thread::scope(|s| {
+            (0..num_workers)
+                .map(|_| {
+                    s.spawn(|| {
+                        let mut results = Vec::new();
+                        loop {
+                            let i = next_i.fetch_add(1, Ordering::Relaxed);
+                            if i >= components.len() {
+                                break;
+                            }
+                            let (name, component) = components[i];
+                            let result = self
+                                .write_component_layer(name, component)
+                                .with_context(|| format!("adding component {name}"));
+                            results.push((i, result));
+                        }
+                        results
+                    })
+                })
+                // force map() above to evaluate and thus spawn the threads
+                .collect::<Vec<_>>()
+                .into_iter()
+                // join threads and flatten their results into a single Vec
+                // SAFETY: a thread panic here would be a bug somewhere in our code (...or a dep)
+                .flat_map(|h| h.join().expect("worker thread panicked"))
+                .collect()
+        });
+
+        // sort back based on index for reproducible builds
+        results.sort_by_key(|(idx, _)| *idx);
+
+        let oci_dir = ocidir::OciDir::open(self.oci_dir.try_clone().context("cloning oci_dir")?)
+            .context("opening OCI directory")?;
+
+        for (_, result) in results {
+            let cl = result?; // NB: this already has 'adding component {name}' context
+            oci_dir.push_layer_with_history_annotated(
+                manifest,
+                config,
+                cl.layer,
+                Some(cl.annotations),
+                Some(cl.history),
+            );
         }
 
         Ok(())
     }
 
-    /// Add a single component as a layer to the OCI directory.
-    fn add_component(
-        &self,
-        manifest: &mut oci_image::ImageManifest,
-        config: &mut oci_image::ImageConfiguration,
-        name: &str,
-        component: &Component,
-    ) -> Result<()> {
+    /// Write a single component as a tar layer. Returns the layer metadata for
+    /// later assembly into the manifest and config.
+    fn write_component_layer(&self, name: &str, component: &Component) -> Result<ComponentLayer> {
         let oci_dir = ocidir::OciDir::open(self.oci_dir.try_clone().context("cloning oci_dir")?)
             .context("opening OCI directory")?;
-        tracing::debug!(components = name, "creating tar layer");
+        tracing::debug!(component = name, "creating tar layer");
         let mut tar_builder =
             crate::tar::create_layer(&oci_dir, self.compression).context("creating layer")?;
 
@@ -195,15 +268,11 @@ impl Builder {
             .build()
             .context("building history entry")?;
 
-        oci_dir.push_layer_with_history_annotated(
-            manifest,
-            config,
+        Ok(ComponentLayer {
             layer,
-            Some(annotations),
-            Some(history),
-        );
-
-        Ok(())
+            annotations,
+            history,
+        })
     }
 }
 

--- a/tools/perf/Justfile
+++ b/tools/perf/Justfile
@@ -2,8 +2,6 @@
 _perf_run_args := "--rm -ti \
     --security-opt=label=disable \
     -v chunkah-perf-cargo:/root/.cargo \
-    -v chunkah-perf-target:/tmp/target \
-    -e CARGO_TARGET_DIR=/tmp/target \
     -e CARGO_PROFILE_RELEASE_DEBUG=true \
     chunkah-perf"
 
@@ -16,9 +14,10 @@ profile image="quay.io/fedora/fedora-minimal:latest": _buildperfimg
     #!/bin/bash
     set -euo pipefail
     podman pull --policy=missing {{ image }}
+    cache_id=$(realpath "$PWD" | sha256sum | cut -f1 -d' ')
     podman run --privileged -v "${PWD}/../..:/build:z" \
         --mount=type=image,src={{ image }},target=/chunkah \
-        {{ _perf_run_args }} \
+        -v chunkah-perf-target-${cache_id}:/build/target {{ _perf_run_args }} \
         sh -c 'cargo flamegraph -o /build/flamegraph.svg -- build --prune /sysroot/ > /dev/null'
 
     echo "Flamegraph written to flamegraph.svg"
@@ -28,7 +27,8 @@ benchmark image="quay.io/fedora/fedora-minimal:latest": _buildperfimg
     #!/bin/bash
     set -euo pipefail
     podman pull --policy=missing {{ image }}
+    cache_id=$(realpath "$PWD" | sha256sum | cut -f1 -d' ')
     podman run -v "${PWD}/../..:/build:z" \
         --mount=type=image,src={{ image }},target=/chunkah \
-        {{ _perf_run_args }} \
-        sh -c 'cargo build --release && hyperfine --warmup 1 "/tmp/target/release/chunkah build --prune /sysroot/ > /dev/null"'
+        -v chunkah-perf-target-${cache_id}:/build/target {{ _perf_run_args }} \
+        sh -c 'cargo build --release && hyperfine --warmup 1 "target/release/chunkah build --prune /sysroot/ > /dev/null"'

--- a/tools/perf/Justfile
+++ b/tools/perf/Justfile
@@ -1,5 +1,5 @@
 # Common podman run args for perf container
-_perf_run_args := "--rm \
+_perf_run_args := "--rm -ti \
     --security-opt=label=disable \
     -v chunkah-perf-cargo:/root/.cargo \
     -v chunkah-perf-target:/tmp/target \


### PR DESCRIPTION
By far the largest time spent during a build is in the tar layer creation (and specifically the SHA-256 calculations). Since tar layers are independent, we can pretty easily parallelize this.

Do this by default, but add a `-T`/`--threads` knob (and `CHUNKAH_THREADS` env) to control this.

This reduces split time for my workstation bootc image (2.5 GiB compressed) from 21s to 12.5s.

Closes https://github.com/coreos/chunkah/issues/15.

Assisted-by: Claude Opus 4.6