### PR TITLE
packit: Add COPR build job for PRs

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -1,11 +1,41 @@
 upstream_tag_template: v{version}
 specfile_path: packaging/chunkah.spec
 
+srpm_build_deps:
+  - cargo
+  - cargo-vendor-filterer
+  - git
+  - openssl-devel
+  - zlib-devel
+
+actions:
+  create-archive:
+    - tools/create-archives.sh --outdir packaging
+  # Packit only handles Source0 by default; we need to also rewrite Source1
+  # (the vendor tarball). Overriding this replaces all default behaviour, so
+  # we must handle Version, Release, and Source0 ourselves too.
+  fix-spec-file:
+    - >-
+        bash -c 'sed -i
+        -e "s/^Version:.*/Version:        ${PACKIT_PROJECT_VERSION}/"
+        -e "s/^Release:.*/Release:        ${PACKIT_RPMSPEC_RELEASE}%{?dist}/"
+        -e "s|^Source0:.*|Source0:        ${PACKIT_PROJECT_ARCHIVE}|"
+        -e "s|^Source1:.*|Source1:        chunkah-${PACKIT_PROJECT_VERSION}-vendor.tar.gz|"
+        packaging/chunkah.spec'
+
 files_to_sync:
   - src: packaging/chunkah.spec
     dest: chunkah.spec
 
 jobs:
+  # Build RPMs in COPR on every PR
+  - job: copr_build
+    trigger: pull_request
+    targets:
+      - fedora-latest-stable
+      - fedora-rawhide
+
+  # Propose updates to Fedora on release
   - job: propose_downstream
     trigger: release
     dist_git_branches:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -3,7 +3,7 @@ name = "chunkah"
 version = "0.2.0"
 description = "An OCI building tool for content-based layers"
 authors = ["Jonathan Lebon <jonathan@jlebon.com>"]
-repository = "https://github.com/jlebon/chunkah"
+repository = "https://github.com/coreos/chunkah"
 license = "MIT OR Apache-2.0"
 edition = "2024"
 # Automatically bumped to match RHEL 9; see .github/workflows/msrv-bump.yml

--- a/Justfile
+++ b/Justfile
@@ -28,7 +28,7 @@ versioncheck:
     set -euo pipefail
     cargo update chunkah --locked
     cargo_version=$(cargo metadata --no-deps --format-version=1 | jq -r '.packages[0].version')
-    line=$(grep -E '^\s+https://github\.com/jlebon/chunkah/releases/download/v[0-9]+\.[0-9]+\.[0-9]+/Containerfile\.splitter$' README.md) \
+    line=$(grep -E '^\s+https://github\.com/coreos/chunkah/releases/download/v[0-9]+\.[0-9]+\.[0-9]+/Containerfile\.splitter$' README.md) \
         || { echo "Could not find Containerfile.splitter download URL in README.md"; exit 1; }
     readme_version=$(echo "${line}" | grep -oP 'download/v\K[0-9]+\.[0-9]+\.[0-9]+')
     if [[ "${cargo_version}" != "${readme_version}" ]]; then

--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ use the `Containerfile.splitter`, passing the target image as the `--from`:
 IMG=quay.io/fedora/fedora-minimal:latest
 buildah build --skip-unused-stages=false --from $IMG \
   --build-arg CHUNKAH_CONFIG_STR="$(podman inspect $IMG)" \
-  https://github.com/jlebon/chunkah/releases/download/v0.2.0/Containerfile.splitter
+  https://github.com/coreos/chunkah/releases/download/v0.2.0/Containerfile.splitter
 ```
 
 Additional arguments can be passed to chunkah using the CHUNKAH_ARGS build

--- a/packaging/chunkah.spec
+++ b/packaging/chunkah.spec
@@ -8,7 +8,7 @@ Summary:        OCI building tool for content-based container image layers
 # chunkah itself is MIT OR Apache-2.0
 # LICENSE.dependencies contains full breakdown of vendored crates
 License:        MIT OR Apache-2.0
-URL:            https://github.com/jlebon/chunkah
+URL:            https://github.com/coreos/chunkah
 Source0:        %{url}/releases/download/v%{version}/%{crate}-%{version}.tar.gz
 Source1:        %{url}/releases/download/v%{version}/%{crate}-%{version}-vendor.tar.gz
 

--- a/tools/create-archives.sh
+++ b/tools/create-archives.sh
@@ -1,0 +1,31 @@
+#!/bin/bash
+# Creates source and vendor tarballs for chunkah.
+# Used by both release.py and Packit's create-archive action.
+# Usage: create-archives.sh <source-tarball> <vendor-tarball>
+#        create-archives.sh --outdir <outdir>
+set -euo pipefail
+shopt -s inherit_errexit
+
+version=$(cargo metadata --no-deps --format-version=1 \
+    | python3 -c 'import json,sys; print(json.load(sys.stdin)["packages"][0]["version"])')
+
+if [[ "${1:-}" == "--outdir" ]]; then
+    outdir="${2:-.}"
+    source_tarball="${outdir}/chunkah-${version}.tar.gz"
+    vendor_tarball="${outdir}/chunkah-${version}-vendor.tar.gz"
+elif [[ $# -ne 2 ]]; then
+    echo "Usage: create-archives.sh <source-tarball> <vendor-tarball>" >&2
+    echo "       create-archives.sh --outdir <outdir>" >&2
+    exit 1
+else
+    source_tarball="${1}"
+    vendor_tarball="${2}"
+fi
+
+git archive --format=tar.gz "--prefix=chunkah-${version}/" \
+    -o "${source_tarball}" HEAD
+
+cargo vendor-filterer --platform '*-unknown-linux-gnu' --tier 2 \
+    --format=tar.gz --prefix=vendor "${vendor_tarball}"
+
+echo "${source_tarball}"

--- a/tools/release.py
+++ b/tools/release.py
@@ -60,11 +60,8 @@ def main():
         step(f"Creating signed tag {tag}...")
         create_signed_tag(tag, edited_notes)
 
-        step("Generating source tarball...")
-        generate_source_tarball(tag, args.version, source_tarball)
-
-        step("Generating vendor tarball...")
-        generate_vendor_tarball(vendor_tarball)
+        step("Generating source and vendor tarballs...")
+        generate_archives(source_tarball, vendor_tarball)
 
         step("Verifying offline build...")
         verify_offline_build(args.version, source_tarball, vendor_tarball)
@@ -178,20 +175,9 @@ def create_signed_tag(tag: str, message: str):
             "-F", f.name)
 
 
-def generate_source_tarball(tag: str, version: str, output: str):
-    """Generate source tarball using git archive."""
-    prefix = f"{NAME}-{version}/"
-    run("git", "archive", "--format=tar.gz", f"--prefix={prefix}",
-        "-o", output, tag)
-
-
-def generate_vendor_tarball(output: str):
-    """Generate vendored dependencies tarball."""
-    run("cargo", "vendor-filterer",
-        "--platform", "*-unknown-linux-*",
-        "--format=tar.gz",
-        "--prefix=vendor",
-        output)
+def generate_archives(source_tarball: str, vendor_tarball: str):
+    """Generate source and vendor tarballs using create-archives.sh."""
+    run("tools/create-archives.sh", source_tarball, vendor_tarball)
 
 
 def verify_offline_build(version: str, source: str, vendor: str):


### PR DESCRIPTION
Add a `copr_build` job to build RPMs in COPR on every PR for
early packaging feedback. The create-archive action calls
`tools/create-archives.sh`, a new shared script that generates source
and vendor tarballs from the current tree. `release.py` is updated to
use the same script, deduplicating the archive creation logic.

Closes: #59
Assisted-by: Claude Opus 4.6