### PR TITLE
packit: add get-current-version to fix PR builds

### DIFF
--- a/.packit.yaml
+++ b/.packit.yaml
@@ -9,6 +9,11 @@ srpm_build_deps:
   - zlib-devel
 
 actions:
+  # Packit defaults to `git describe` for the version, but for PRs that bump the
+  # Cargo.toml release, the versioned tarball that create-archive produces will
+  # not match what Packit expects. Always get the version from Cargo.toml.
+  get-current-version:
+    - bash -c 'cargo metadata --no-deps --format-version=1 | python3 -c "import json,sys; print(json.load(sys.stdin)[\"packages\"][0][\"version\"])"'
   create-archive:
     - tools/create-archives.sh --outdir packaging
   # Packit only handles Source0 by default; we need to also rewrite Source1


### PR DESCRIPTION
Packit defaults to `git describe` for the project version. So when cutting a release, on PRs where we're bumping the chunkah version in `Cargo.toml`, we get a mismatch: `create-archives.sh` reads the version from `Cargo.toml` (e.g. 0.3.0), but `PACKIT_PROJECT_VERSION` resolved to 0.2.0 from the last tag, so `fix-spec-file` referenced a vendor tarball that didn't exist.

Add a `get-current-version` action that reads the version from `Cargo.toml` via `cargo metadata`, keeping `PACKIT_PROJECT_VERSION` consistent with the archives that `create-archives.sh` produces.

Assisted-by: OpenCode (Claude Opus 4.6)