### PR TITLE
tree: update quay.io image references to coreos org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,12 +121,12 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
             skopeo copy --all --src-creds=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
-              docker://ghcr.io/${{ github.repository }}:${{ github.sha }} docker://quay.io/jlebon/chunkah:${TAG}
+              docker://ghcr.io/${{ github.repository }}:${{ github.sha }} docker://quay.io/coreos/chunkah:${TAG}
             skopeo copy --all --src-creds=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
-              docker://ghcr.io/${{ github.repository }}:${{ github.sha }} docker://quay.io/jlebon/chunkah:latest
+              docker://ghcr.io/${{ github.repository }}:${{ github.sha }} docker://quay.io/coreos/chunkah:latest
           else
             skopeo copy --all --src-creds=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
-              docker://ghcr.io/${{ github.repository }}:${{ github.sha }} docker://quay.io/jlebon/chunkah:dev
+              docker://ghcr.io/${{ github.repository }}:${{ github.sha }} docker://quay.io/coreos/chunkah:dev
           fi
       - name: Cleanup old images
         uses: actions/delete-package-versions@v5

--- a/Containerfile.splitter
+++ b/Containerfile.splitter
@@ -1,7 +1,7 @@
 # This file is used to split existing images using `buildah build`. See
 # README.md for how to use it.
 
-ARG CHUNKAH=quay.io/jlebon/chunkah:latest
+ARG CHUNKAH=quay.io/coreos/chunkah:latest
 ARG CHUNKAH_ARGS=""
 ARG CHUNKAH_CONFIG_STR
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ preprocess the rootfs to remove common sources of non-reproducibility (such as
 chunkah is primarily intended to be used as a container image:
 
 ```shell
-podman run -ti --rm quay.io/jlebon/chunkah --help
+podman run -ti --rm quay.io/coreos/chunkah --help
 ```
 
 However, if you're currently building images using a multi-stage build, it
@@ -113,7 +113,7 @@ IMG=quay.io/fedora/fedora-minimal:latest
 podman pull $IMG # image must be available locally
 export CHUNKAH_CONFIG_STR="$(podman inspect $IMG)"
 podman run --rm --mount=type=image,src=$IMG,dest=/chunkah \
-  -e CHUNKAH_CONFIG_STR quay.io/jlebon/chunkah build | podman load
+  -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah build | podman load
 ```
 
 #### Using Docker/Moby
@@ -125,7 +125,7 @@ IMG=quay.io/fedora/fedora-minimal:latest
 docker pull $IMG # image must be available locally
 export CHUNKAH_CONFIG_STR="$(docker inspect $IMG)"
 docker run --rm --mount=type=image,src=$IMG,destination=/chunkah \
-  -e CHUNKAH_CONFIG_STR quay.io/jlebon/chunkah build > out.ociarchive
+  -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah build > out.ociarchive
 docker run --rm -ti -v $(pwd):/srv:z -w /srv quay.io/skopeo/stable \
   copy oci-archive:out.ociarchive docker-archive:out.dockerarchive
 docker load -i out.dockerarchive
@@ -150,7 +150,7 @@ ARG CHUNKAH_CONFIG_STR
 FROM quay.io/fedora/fedora-minimal:latest AS builder
 RUN dnf install -y git-core && dnf clean all
 
-FROM quay.io/jlebon/chunkah AS chunkah
+FROM quay.io/coreos/chunkah AS chunkah
 ARG CHUNKAH_CONFIG_STR
 RUN --mount=from=builder,src=/,target=/chunkah,ro \
     --mount=type=bind,target=/run/src,rw \
@@ -221,7 +221,7 @@ rootfs, regardless of where it comes from:
 ```shell
 podman run --rm -v /path/to/rootfs:/chunkah:z \
   -e CHUNKAH_CONFIG_STR="$(cat config.json)" \
-  quay.io/jlebon/chunkah build > out.ociarchive
+  quay.io/coreos/chunkah build > out.ociarchive
 ```
 
 > [!NOTE]
@@ -310,7 +310,7 @@ FROM quay.io/fedora/fedora-bootc:latest AS builder
 RUN dnf install -y tmux && dnf clean all
 RUN bootc container lint
 
-FROM quay.io/jlebon/chunkah AS chunkah
+FROM quay.io/coreos/chunkah AS chunkah
 ARG CHUNKAH_CONFIG_STR
 RUN --mount=from=builder,src=/,target=/chunkah,ro \
     --mount=type=bind,target=/run/src,rw \

--- a/tools/chunk-image-series.py
+++ b/tools/chunk-image-series.py
@@ -59,8 +59,8 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--chunkah-image",
-        default="quay.io/jlebon/chunkah",
-        help="Chunkah image to use (default: quay.io/jlebon/chunkah)",
+        default="quay.io/coreos/chunkah",
+        help="Chunkah image to use (default: quay.io/coreos/chunkah)",
     )
     parser.add_argument(
         "--dry-run",


### PR DESCRIPTION
Past versions have been migrated from quay.io/jlebon/chunkah to quay.io/coreos/chunkah. Update all references to point to the new location, including the CI workflow, docs, and tooling.

Assisted-by: OpenCode (Claude Opus 4.6)