### PR TITLE
xattr: support `user.update-interval` xattr for component stability

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,20 @@ RUN setfattr -n user.component -v "custom-apps" /usr/bin/my-app
 This is compatible with rpm-ostree's support for [the same
 feature](https://coreos.github.io/rpm-ostree/build-chunked-oci/#assigning-files-to-specific-layers).
 
+In addition, the `user.update-interval` xattr is also supported. The value is
+the average number of days between updates, either as an integer or a named
+label (`daily`, `weekly`, `biweekly`, `monthly`, `quarterly`, `yearly`), e.g.:
+
+```Dockerfile
+RUN setfattr -n user.component -v "custom-apps" /usr/bin/my-app && \
+    setfattr -n user.update-interval -v "monthly" /usr/bin/my-app
+```
+
+It is strongly recommended to set this xattr. A rough approximation is fine.
+This helps the packing algorithm make better decisions about which components to
+group together. Components without this information are treated as less stable
+than any component with a known update interval.
+
 ### Limiting the number of layers
 
 By default, the maximum number of layers emitted is 64. This can be increased or

--- a/src/cmd_build.rs
+++ b/src/cmd_build.rs
@@ -235,7 +235,7 @@ pub fn run(args: &BuildArgs) -> Result<()> {
     }
 
     // pack components down to max layers
-    let components = pack_components(args, components).context("packing components")?;
+    let components = pack_components(args.max_layers, components).context("packing components")?;
     tracing::info!(layers = components.len(), "packing complete");
 
     // build the OCI image
@@ -475,11 +475,9 @@ fn parse_key_value_pairs(
 
 /// Packs components into layers according to max_layers constraint.
 fn pack_components(
-    args: &BuildArgs,
+    max_layers: usize,
     components: HashMap<String, Component>,
 ) -> Result<Vec<(String, Component)>> {
-    let max_layers = args.max_layers;
-
     let mut entries: Vec<Option<(String, Component)>> = components.into_iter().map(Some).collect();
     // sort by component name for deterministic inputs to the packing algorithm
     entries.sort_by(|a, b| a.as_ref().unwrap().0.cmp(&b.as_ref().unwrap().0));
@@ -810,5 +808,82 @@ mod tests {
         assert_eq!(labels.get("existing"), Some(&"from-config".to_string()));
         assert_eq!(labels.get("override-me"), Some(&"new-value".to_string()));
         assert_eq!(labels.get("new-label"), Some(&"second".to_string()));
+    }
+
+    #[test]
+    fn test_packing_with_xattrs() {
+        use camino::Utf8Path;
+        use cap_std_ext::dirext::CapStdExtDirExt;
+
+        const MB: usize = 1024 * 1024;
+        const XATTR_COMPONENT: &str = "user.component";
+        const XATTR_INTERVAL: &str = "user.update-interval";
+
+        // Helper to set up a rootfs with 3 files (3M, 2M, 1M), load components
+        // with the given update intervals, and pack into 2 layers.
+        let pack = |large_interval: &str, medium_interval: &str, small_interval: &str| {
+            let tmp = tempfile::tempdir().unwrap();
+            let rootfs = Dir::open_ambient_dir(tmp.path(), ambient_authority()).unwrap();
+
+            let add_component = |name: &str, size_mb: usize, interval: &str| {
+                rootfs.write(name, &vec![0u8; size_mb * MB]).unwrap();
+                rootfs
+                    .setxattr(name, XATTR_COMPONENT, name.as_bytes())
+                    .unwrap();
+                rootfs
+                    .setxattr(name, XATTR_INTERVAL, interval.as_bytes())
+                    .unwrap();
+            };
+
+            add_component("large", 3, large_interval);
+            add_component("medium", 2, medium_interval);
+            add_component("small", 1, small_interval);
+
+            let files = crate::scan::Scanner::new(&rootfs).scan().unwrap();
+            let repos = ComponentsRepos::load(&rootfs, &files, 0).unwrap();
+            let components = repos.into_components(&rootfs, files).unwrap();
+            pack_components(2, components).unwrap()
+        };
+
+        // Helper to find which packed layer contains a given file.
+        let find_layer = |packed: &Vec<(String, Component)>, path: &str| -> usize {
+            packed
+                .iter()
+                .position(|(_, c)| c.files.contains_key(Utf8Path::new(path)))
+                .unwrap_or_else(|| panic!("{path} not found in any layer"))
+        };
+
+        // Scenario 1: 3M daily, 2M daily, 1M yearly
+        // The 1M yearly is stable, so it should get its own layer. The 3M+2M
+        // daily should merge (both unstable, lowest TEV loss).
+        let packed = pack("daily", "daily", "yearly");
+        assert_eq!(packed.len(), 2);
+        assert_eq!(
+            find_layer(&packed, "/large"),
+            find_layer(&packed, "/medium"),
+            "unstable large+medium should be in the same layer"
+        );
+        assert_ne!(
+            find_layer(&packed, "/large"),
+            find_layer(&packed, "/small"),
+            "stable small should be separate from unstable large"
+        );
+
+        // Scenario 2: 3M daily, 2M yearly, 1M yearly
+        // Now the 2M joins the stable camp. The two stable components merge
+        // (low TEV loss since combined stability barely drops), and the 3M
+        // daily gets its own layer.
+        let packed = pack("daily", "yearly", "yearly");
+        assert_eq!(packed.len(), 2);
+        assert_eq!(
+            find_layer(&packed, "/medium"),
+            find_layer(&packed, "/small"),
+            "stable medium+small should be in the same layer"
+        );
+        assert_ne!(
+            find_layer(&packed, "/large"),
+            find_layer(&packed, "/medium"),
+            "unstable large should be separate from stable medium"
+        );
     }
 }

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -244,6 +244,13 @@ impl ComponentsRepos {
         // bigfiles, unclaimed). Use half the minimum non-zero stability so
         // they're considered less stable than any known component, but non-zero
         // so the packing algorithm can make meaningful TEV loss calculations.
+        //
+        // The reasoning here is that it's better to wrongly underestimate
+        // stability than it is to overestimate it. In the latter case, it
+        // could contaminate components that are _known_ stable or take up a
+        // precious layer slot that could be used by known stable components.
+        // In the former case, it could still be in its own layer if the size
+        // warrants it but otherwise goes in the catch-all.
         let min_stability = components
             .values()
             .map(|c| c.stability)

--- a/src/components/xattr.rs
+++ b/src/components/xattr.rs
@@ -4,9 +4,12 @@ use anyhow::{Context, Result};
 use camino::{Utf8Path, Utf8PathBuf};
 use indexmap::IndexSet;
 
-use super::{ComponentId, ComponentInfo, ComponentsRepo, FileInfo, FileMap, FileType};
+use super::{
+    ComponentId, ComponentInfo, ComponentsRepo, FileInfo, FileMap, FileType, STABILITY_PERIOD_DAYS,
+};
 
 const XATTR_NAME: &str = "user.component";
+const UPDATE_INTERVAL_XATTR_NAME: &str = "user.update-interval";
 const REPO_NAME: &str = "xattr";
 
 /// Xattr-based components repo implementation.
@@ -19,6 +22,8 @@ pub struct XattrRepo {
     components: IndexSet<String>,
     /// Mapping from path to ComponentId (pre-computed with inheritance).
     path_to_component: HashMap<Utf8PathBuf, ComponentId>,
+    /// Per-component stability, indexed by ComponentId.
+    component_stability: Vec<f64>,
     /// Currently, the on-disk mtime is canonical and we clamp it, but it would
     /// make sense in the future to support another user xattr to specify a
     /// canonical mtime for easier layer reproducibility.
@@ -32,6 +37,8 @@ impl XattrRepo {
     pub fn load(files: &FileMap, default_mtime_clamp: u64) -> Result<Option<Self>> {
         let mut components: IndexSet<String> = IndexSet::new();
         let mut path_to_component: HashMap<Utf8PathBuf, ComponentId> = HashMap::new();
+        // Track raw intervals during scanning to detect conflicts
+        let mut update_intervals: Vec<Option<u64>> = Vec::new();
 
         // Track active directory components: (path, ComponentId)
         // Directories with xattrs apply their component to descendants
@@ -56,6 +63,7 @@ impl XattrRepo {
                 // https://github.com/indexmap-rs/indexmap/issues/388
                 let idx = components.get_index_of(name).unwrap_or_else(|| {
                     let idx = components.insert_full(name.clone()).0;
+                    update_intervals.push(None);
                     tracing::trace!(path = %path, name = %name, id = idx, "xattr component created");
                     idx
                 });
@@ -75,12 +83,54 @@ impl XattrRepo {
             if let Some(id) = effective_id {
                 tracing::trace!(path = %path, component_id = id.0, "xattr assignment");
                 path_to_component.insert(path.clone(), id);
+
+                // Check for user.update-interval xattr (not inherited from directories)
+                if let Some(interval) = get_update_interval_xattr(file_info)
+                    .with_context(|| format!("reading update interval xattr for {path}"))?
+                {
+                    let existing = &mut update_intervals[id.0];
+                    match *existing {
+                        Some(prev) if prev != interval => {
+                            let name = &components[id.0];
+                            anyhow::bail!(
+                                "conflicting {UPDATE_INTERVAL_XATTR_NAME} values for component \
+                                 {name}: {prev} and {interval} (at {path})"
+                            );
+                        }
+                        Some(_) => {} // same value, no-op
+                        None => {
+                            *existing = Some(interval);
+                            tracing::debug!(
+                                path = %path,
+                                component = &components[id.0],
+                                interval_days = interval,
+                                "update-interval xattr set"
+                            );
+                        }
+                    }
+                }
             }
         }
 
         if components.is_empty() {
             return Ok(None);
         }
+
+        // Convert raw intervals to stability probabilities
+        let component_stability: Vec<f64> = update_intervals
+            .iter()
+            .enumerate()
+            .map(|(idx, interval)| match interval {
+                Some(days) => interval_to_stability(*days),
+                None => {
+                    tracing::warn!(
+                        component = &components[idx],
+                        "no {UPDATE_INTERVAL_XATTR_NAME} set, packing may be suboptimal"
+                    );
+                    0.0
+                }
+            })
+            .collect();
 
         tracing::debug!(
             components = components.len(),
@@ -91,6 +141,7 @@ impl XattrRepo {
         Ok(Some(Self {
             components,
             path_to_component,
+            component_stability,
             default_mtime_clamp,
         }))
     }
@@ -98,15 +149,56 @@ impl XattrRepo {
 
 /// Extract the user.component xattr value from cached xattrs.
 fn get_component_xattr(file_info: &FileInfo) -> Result<Option<String>> {
+    get_xattr_string(file_info, XATTR_NAME)
+}
+
+/// Extract the user.update-interval xattr value as an interval in days.
+fn get_update_interval_xattr(file_info: &FileInfo) -> Result<Option<u64>> {
+    get_xattr_string(file_info, UPDATE_INTERVAL_XATTR_NAME)?
+        .map(|v| parse_update_interval_xattr(&v))
+        .transpose()
+}
+
+/// Extract a string xattr value from cached xattrs.
+fn get_xattr_string(file_info: &FileInfo, name: &str) -> Result<Option<String>> {
     file_info
         .xattrs
         .iter()
-        .find(|(k, _)| k == XATTR_NAME)
+        .find(|(k, _)| k == name)
         .map(|(_, v)| {
             String::from_utf8(v.clone())
-                .map_err(|e| anyhow::anyhow!("invalid UTF-8 in {XATTR_NAME} xattr: {e}"))
+                .map_err(|e| anyhow::anyhow!("invalid UTF-8 in {name} xattr: {e}"))
         })
         .transpose()
+}
+
+/// Parse a user.update-interval xattr value into an interval in days.
+///
+/// Accepts either a positive integer (number of days) or a named label:
+/// daily (1), weekly (7), biweekly (14), monthly (30), quarterly (90),
+/// yearly (365).
+fn parse_update_interval_xattr(value: &str) -> Result<u64> {
+    let interval = match value {
+        "daily" => 1,
+        "weekly" => 7,
+        "biweekly" => 14,
+        "monthly" => 30,
+        "quarterly" => 90,
+        "yearly" => 365,
+        _ => value
+            .parse::<u64>()
+            .with_context(|| format!("invalid {UPDATE_INTERVAL_XATTR_NAME} value: {value:?}"))?,
+    };
+    anyhow::ensure!(
+        interval > 0,
+        "invalid {UPDATE_INTERVAL_XATTR_NAME} value: must be a positive integer, got {value:?}"
+    );
+    Ok(interval)
+}
+
+/// Convert a stability interval in days to a probability using the Poisson model.
+fn interval_to_stability(interval_days: u64) -> f64 {
+    (-STABILITY_PERIOD_DAYS / interval_days as f64).exp()
 }
 
 impl ComponentsRepo for XattrRepo {
@@ -138,8 +230,7 @@ impl ComponentsRepo for XattrRepo {
                 // when we inserted the element, so it must be valid.
                 .expect("invalid ComponentId"),
             mtime_clamp: self.default_mtime_clamp,
-            // TODO: make this configurable via xattr or CLI
-            stability: 0.0,
+            stability: self.component_stability[id.0],
         }
     }
 }
@@ -169,6 +260,13 @@ mod tests {
     fn set_component(rootfs: &Dir, path: &str, component: &str) {
         rootfs
             .setxattr(path, XATTR_NAME, component.as_bytes())
+            .unwrap();
+    }
+
+    /// Helper to set the update-interval xattr on a path.
+    fn set_update_interval(rootfs: &Dir, path: &str, value: &str) {
+        rootfs
+            .setxattr(path, UPDATE_INTERVAL_XATTR_NAME, value.as_bytes())
             .unwrap();
     }
 
@@ -260,5 +358,83 @@ mod tests {
         // Both should be claimed by mycomp
         assert_component(&repo, "/mydir", FileType::Directory, "mycomp");
         assert_component(&repo, "/mydir/link", FileType::Symlink, "mycomp");
+    }
+
+    #[test]
+    fn test_xattr_stability_named_labels() {
+        // Test that named labels are parsed correctly
+        assert_eq!(parse_update_interval_xattr("daily").unwrap(), 1);
+        assert_eq!(parse_update_interval_xattr("weekly").unwrap(), 7);
+        assert_eq!(parse_update_interval_xattr("biweekly").unwrap(), 14);
+        assert_eq!(parse_update_interval_xattr("monthly").unwrap(), 30);
+        assert_eq!(parse_update_interval_xattr("quarterly").unwrap(), 90);
+        assert_eq!(parse_update_interval_xattr("yearly").unwrap(), 365);
+    }
+
+    #[test]
+    fn test_xattr_stability_invalid_values() {
+        assert!(parse_update_interval_xattr("0").is_err());
+        assert!(parse_update_interval_xattr("-1").is_err());
+        assert!(parse_update_interval_xattr("abc").is_err());
+        assert!(parse_update_interval_xattr("3.5").is_err());
+        assert!(parse_update_interval_xattr("").is_err());
+    }
+
+    #[test]
+    fn test_xattr_stability_conflicting_values() {
+        let (_tmp, files) = setup_rootfs(|rootfs| {
+            rootfs.create_dir("mydir").unwrap();
+            set_component(rootfs, "mydir", "mycomp");
+            set_update_interval(rootfs, "mydir", "30");
+            rootfs.write("mydir/file", "content").unwrap();
+            set_update_interval(rootfs, "mydir/file", "60");
+        });
+        let result = XattrRepo::load(&files, 0);
+        assert!(result.is_err());
+        let msg = format!("{:#}", result.err().unwrap());
+        assert!(msg.contains("conflicting"), "unexpected error: {msg}");
+    }
+
+    #[test]
+    fn test_xattr_stability_agreeing_values() {
+        let (_tmp, files) = setup_rootfs(|rootfs| {
+            rootfs.create_dir("mydir").unwrap();
+            set_component(rootfs, "mydir", "mycomp");
+            set_update_interval(rootfs, "mydir", "monthly");
+            rootfs.write("mydir/file", "content").unwrap();
+            set_update_interval(rootfs, "mydir/file", "30");
+        });
+        let repo = XattrRepo::load(&files, 0).unwrap().unwrap();
+
+        let claims = repo.strong_claims_for_path(Utf8Path::new("/mydir"), &fi(FileType::Directory));
+        let expected = interval_to_stability(30);
+        assert_eq!(repo.component_info(claims[0]).stability, expected);
+    }
+
+    #[test]
+    fn test_xattr_stability_not_inherited() {
+        // user.update-interval on one component shouldn't affect another
+        let (_tmp, files) = setup_rootfs(|rootfs| {
+            rootfs.create_dir("app1").unwrap();
+            set_component(rootfs, "app1", "comp1");
+            set_update_interval(rootfs, "app1", "yearly");
+            rootfs.write("app1/file", "content").unwrap();
+
+            rootfs.create_dir("app2").unwrap();
+            set_component(rootfs, "app2", "comp2");
+            rootfs.write("app2/file", "content").unwrap();
+        });
+        let repo = XattrRepo::load(&files, 0).unwrap().unwrap();
+
+        // comp1 should have yearly stability
+        let claims = repo.strong_claims_for_path(Utf8Path::new("/app1"), &fi(FileType::Directory));
+        assert_eq!(
+            repo.component_info(claims[0]).stability,
+            interval_to_stability(365)
+        );
+
+        // comp2 should have the default (0.0, filled in by fallback later)
+        let claims = repo.strong_claims_for_path(Utf8Path::new("/app2"), &fi(FileType::Directory));
+        assert_eq!(repo.component_info(claims[0]).stability, 0.0);
     }
 }

--- a/src/ocibuilder.rs
+++ b/src/ocibuilder.rs
@@ -89,7 +89,7 @@ impl Builder {
     pub fn build<W: Write>(self, output: &mut W) -> Result<()> {
         self.build_oci_dir().context("building OCI directory")?;
 
-        let compressed = matches!(self.compression, Compression::Gzip(_));
+        let compressed = !matches!(self.compression, Compression::None);
         tracing::info!(compressed = compressed, "writing OCI archive");
 
         let compression = match self.compression {
@@ -165,6 +165,7 @@ impl Builder {
         tracing::info!(
             threads = num_workers,
             layers = components.len(),
+            compressed = !matches!(self.compression, Compression::None),
             "writing layers"
         );
 

--- a/tools/perf/Justfile
+++ b/tools/perf/Justfile
@@ -23,7 +23,7 @@ profile image="quay.io/fedora/fedora-minimal:latest": _buildperfimg
     echo "Flamegraph written to flamegraph.svg"
 
 # Benchmark chunkah with hyperfine
-benchmark image="quay.io/fedora/fedora-minimal:latest": _buildperfimg
+benchmark image="quay.io/fedora/fedora-coreos:stable": _buildperfimg
     #!/bin/bash
     set -euo pipefail
     podman pull --policy=missing {{ image }}
@@ -31,4 +31,4 @@ benchmark image="quay.io/fedora/fedora-minimal:latest": _buildperfimg
     podman run -v "${PWD}/../..:/build:z" \
         --mount=type=image,src={{ image }},target=/chunkah \
         -v chunkah-perf-target-${cache_id}:/build/target {{ _perf_run_args }} \
-        sh -c 'cargo build --release && hyperfine --warmup 1 "target/release/chunkah build --prune /sysroot/ > /dev/null"'
+        sh -c 'cargo build --release && hyperfine --warmup 3 "target/release/chunkah build --prune /sysroot/ > target/out.ociarchive"'


### PR DESCRIPTION
Allow users to specify the stability of xattr components via `user.update-interval`. The value can be either a positive integer representing the average update interval in days (e.g. '30') or a named label (daily, weekly, biweekly, monthly, quarterly, yearly). That makes it easier to understand than having them plug in the probability directly.

This plugs a notable gap we've had so far in the xattr repo, which without this information was useful mostly when there was no to little packing pressure. As soon as aggressive packing is required, treating a high stability component as low can lead to suboptimal outcomes.

Closes: #98
Assisted-by: OpenCode (Claude Opus 4.6)