### PR TITLE
xattr: default to weekly stability if missing

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,9 +188,8 @@ for other distros). There is also an xattr-based component repo (see the section
 
 ### Customizing the layers
 
-It is possible to modify how components are assigned to layers by setting the
-`user.component` xattr on files/directories. This can be done using `setfattr`,
-e.g.:
+It is possible to create custom components by setting the `user.component` xattr
+on files/directories. This can be done using `setfattr`, e.g.:
 
 ```Dockerfile
 RUN setfattr -n user.component -v "custom-apps" /usr/bin/my-app
@@ -198,6 +197,8 @@ RUN setfattr -n user.component -v "custom-apps" /usr/bin/my-app
 
 This is compatible with rpm-ostree's support for [the same
 feature](https://coreos.github.io/rpm-ostree/build-chunked-oci/#assigning-files-to-specific-layers).
+However, unlike rpm-ostree, this does not guarantee unique layers per xattr
+component.
 
 In addition, the `user.update-interval` xattr is also supported. The value is
 the average number of days between updates, either as an integer or a named
@@ -210,8 +211,7 @@ RUN setfattr -n user.component -v "custom-apps" /usr/bin/my-app && \
 
 It is strongly recommended to set this xattr. A rough approximation is fine.
 This helps the packing algorithm make better decisions about which components to
-group together. Components without this information are treated as less stable
-than any component with a known update interval.
+group together. When missing, defaults to `weekly`.
 
 ### Limiting the number of layers
 

--- a/src/components/xattr.rs
+++ b/src/components/xattr.rs
@@ -10,6 +10,7 @@ use super::{
 
 const XATTR_NAME: &str = "user.component";
 const UPDATE_INTERVAL_XATTR_NAME: &str = "user.update-interval";
+const UPDATE_INTERVAL_DEFAULT: u64 = 7; // i.e. weekly
 const REPO_NAME: &str = "xattr";
 
 /// Xattr-based components repo implementation.
@@ -123,11 +124,11 @@ impl XattrRepo {
             .map(|(idx, interval)| match interval {
                 Some(days) => interval_to_stability(*days),
                 None => {
-                    tracing::warn!(
+                    tracing::debug!(
                         component = &components[idx],
-                        "no {UPDATE_INTERVAL_XATTR_NAME} set, packing may be suboptimal"
+                        "no {UPDATE_INTERVAL_XATTR_NAME} set, defaulting to {UPDATE_INTERVAL_DEFAULT} days"
                     );
-                    0.0
+                    interval_to_stability(UPDATE_INTERVAL_DEFAULT)
                 }
             })
             .collect();
@@ -433,8 +434,11 @@ mod tests {
             interval_to_stability(365)
         );
 
-        // comp2 should have the default (0.0, filled in by fallback later)
+        // comp2 should have the default (weekly)
         let claims = repo.strong_claims_for_path(Utf8Path::new("/app2"), &fi(FileType::Directory));
-        assert_eq!(repo.component_info(claims[0]).stability, 0.0);
+        assert_eq!(
+            repo.component_info(claims[0]).stability,
+            interval_to_stability(7)
+        );
     }
 }

--- a/src/components/xattr.rs
+++ b/src/components/xattr.rs
@@ -118,12 +118,14 @@ impl XattrRepo {
         }
 
         // Convert raw intervals to stability probabilities
+        let mut n_defaulted = 0u32;
         let component_stability: Vec<f64> = update_intervals
             .iter()
             .enumerate()
             .map(|(idx, interval)| match interval {
                 Some(days) => interval_to_stability(*days),
                 None => {
+                    n_defaulted += 1;
                     tracing::debug!(
                         component = &components[idx],
                         "no {UPDATE_INTERVAL_XATTR_NAME} set, defaulting to {UPDATE_INTERVAL_DEFAULT} days"
@@ -132,6 +134,14 @@ impl XattrRepo {
                 }
             })
             .collect();
+
+        if n_defaulted > 10 {
+            tracing::warn!(
+                defaulted = n_defaulted,
+                "many xattr components without {UPDATE_INTERVAL_XATTR_NAME}, \
+                 consider setting it for better packing"
+            );
+        }
 
         tracing::debug!(
             components = components.len(),


### PR DESCRIPTION
This is the second part of #98. If the user didn't provide any interval via the new xattr API, assume weekly.

Previously, we were using the fallback of (minimum stability)/2, which (1) is way too sensitive to churny outliers in the package set, and (2) doesn't really have a basis in what users are expressing.

I'm converting users' intent of bothering to add an xattr here as them saying that it has _some_ amount of stability, which I'm semi-arbitrarily ballparking as 'weekly'.

While we're here, tweak the README section on xattrs a bit more to reflect reality.