### PR TITLE
build: add support for `-t`/`--tag` switch

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,8 +109,13 @@ IMG=quay.io/fedora/fedora-minimal:latest
 podman pull $IMG # image must be available locally
 export CHUNKAH_CONFIG_STR="$(podman inspect $IMG)"
 podman run --rm --mount=type=image,src=$IMG,dest=/chunkah \
-  -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah build | podman load
+  -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah build \
+    -t localhost/fedora-minimal-chunked:latest | podman load
 ```
+
+The `-t`/`--tag` option sets the image name in the OCI archive so that `podman
+load` automatically tags the loaded image. Without it, the image is loaded as an
+unnamed image identified only by its digest.
 
 #### Using Docker/Moby
 
@@ -121,14 +126,23 @@ IMG=quay.io/fedora/fedora-minimal:latest
 docker pull $IMG # image must be available locally
 export CHUNKAH_CONFIG_STR="$(docker inspect $IMG)"
 docker run --rm --mount=type=image,src=$IMG,destination=/chunkah \
-  -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah build > out.ociarchive
+  -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah build \
+    -t localhost/fedora-minimal-chunked:latest | docker load
+```
+
+Note `docker load` support for OCI archives requires the [containerd image
+store] (default on new installations starting from v29+). If using the legacy
+graph driver, instead of piping directly into `docker load` as above, you can
+redirect to a file to save the OCI archive, and then use skopeo to convert to
+the Docker archive format:
+
+```shell
 docker run --rm -ti -v $(pwd):/srv:z -w /srv quay.io/skopeo/stable \
-  copy oci-archive:out.ociarchive docker-archive:out.dockerarchive
+  copy oci-archive:out.ociarchive docker-archive:out.dockerarchive:chunked
 docker load -i out.dockerarchive
 ```
 
-Note the conversion step using `skopeo`; `chunkah` currently only outputs an OCI
-archive, which `docker load` does not natively support.
+[containerd image store]: https://docs.docker.com/engine/storage/containerd/
 
 ### Splitting an image at build time (buildah/podman only)
 

--- a/src/cmd_build.rs
+++ b/src/cmd_build.rs
@@ -105,6 +105,14 @@ pub struct BuildArgs {
     #[arg(long = "prune", value_name = "PATH")]
     prune: Vec<Utf8PathBuf>,
 
+    /// Tag to apply to the image in the OCI archive
+    ///
+    /// Sets the org.opencontainers.image.ref.name annotation on the manifest
+    /// descriptor in index.json, so that `podman load`/`docker load` tags the
+    /// image with this name instead of loading it as an unnamed image.
+    #[arg(short = 't', long, value_name = "NAME")]
+    tag: Option<String>,
+
     /// Number of threads for parallel layer writing (0 = auto-detect)
     #[arg(short = 'T', long, default_value_t = 0, env = "CHUNKAH_THREADS")]
     threads: usize,
@@ -255,12 +263,15 @@ pub fn run(args: &BuildArgs) -> Result<()> {
         }
     });
 
-    let builder = Builder::new(&rootfs, components)
+    let mut builder = Builder::new(&rootfs, components)
         .context("creating builder")?
         .compression(compression)
         .threads(threads)
         .annotations(annotations)
         .config(image_config);
+    if let Some(tag) = &args.tag {
+        builder = builder.tag(tag.clone());
+    }
 
     if let Some(output_path) = &args.output {
         tracing::info!(output = %output_path, "writing to file");

--- a/src/ocibuilder.rs
+++ b/src/ocibuilder.rs
@@ -33,6 +33,8 @@ pub struct Builder {
     threads: NonZeroUsize,
     /// Annotations to add to the image manifest.
     annotations: Option<HashMap<String, String>>,
+    /// Tag to set on the manifest descriptor in index.json.
+    tag: Option<String>,
     /// The image configuration.
     config: Option<oci_image::ImageConfiguration>,
 }
@@ -57,6 +59,7 @@ impl Builder {
             compression: Compression::default(),
             threads: NonZeroUsize::MIN,
             annotations: None,
+            tag: None,
             config: None,
         })
     }
@@ -76,6 +79,16 @@ impl Builder {
     /// Set annotations to add to the image manifest.
     pub fn annotations(mut self, annotations: HashMap<String, String>) -> Self {
         self.annotations = Some(annotations);
+        self
+    }
+
+    /// Set the tag for the manifest descriptor in index.json.
+    ///
+    /// This sets the `org.opencontainers.image.ref.name` annotation on the
+    /// manifest descriptor, which causes `podman load`/`docker load` to tag the
+    /// loaded image with this name.
+    pub fn tag(mut self, tag: String) -> Self {
+        self.tag = Some(tag);
         self
     }
 
@@ -135,7 +148,7 @@ impl Builder {
             .context("building platform")?;
 
         oci_dir
-            .insert_manifest_and_config(manifest, config, None, platform)
+            .insert_manifest_and_config(manifest, config, self.tag.as_deref(), platform)
             .context("inserting manifest and config")?;
 
         Ok(())

--- a/tests/e2e/test-existing-run.sh
+++ b/tests/e2e/test-existing-run.sh
@@ -21,12 +21,7 @@ CHUNKAH_CONFIG_STR=$(podman inspect "${SOURCE_IMAGE}")
 # run chunkah!
 podman run --rm --mount=type=image,src="${SOURCE_IMAGE}",target=/chunkah \
   -e CHUNKAH_CONFIG_STR="${CHUNKAH_CONFIG_STR}" \
-      "${CHUNKAH_IMG:?}" build -v > out.ociarchive
-
-# XXX: need to fix 'podman load' to only print image ID on its stdout, like 'podman pull'
-iid=$(podman load -i out.ociarchive)
-iid=${iid#*sha256:}
-podman tag "${iid}" "${CHUNKED_IMAGE}"
+      "${CHUNKAH_IMG:?}" build -v -t "${CHUNKED_IMAGE}" | podman load
 
 # sanity-check it
 podman run --rm "${CHUNKED_IMAGE}" cat /etc/os-release | grep Fedora


### PR DESCRIPTION
In the `podman run chunkah | podman load` flow for splitting an existing image, it's annoying that the resulting image is unnamed. Add support for a `-t`/`--tag` switch which sets the right annotation on the manifest descriptor in the OCI archive that e.g. `podman` and `docker` pay attention to.

While we're here, update the Docker docs; the containerd backend does support OCI archives natively and that's the default backend nowadays. So that simplifies things nicely and makes it almost identical to the podman instructions.

Assisted-by: OpenCode (Claude Opus 4.6)