### PR TITLE
components: add filemap backend for provenance-aware build systems

### DIFF
--- a/src/components/filemap.rs
+++ b/src/components/filemap.rs
@@ -1,0 +1,273 @@
+use std::collections::HashMap;
+
+use anyhow::{Context, Result};
+use camino::{Utf8Path, Utf8PathBuf};
+use cap_std_ext::cap_std::fs::Dir;
+use indexmap::IndexSet;
+use serde::Deserialize;
+
+use super::{ComponentId, ComponentInfo, ComponentsRepo, FileMap, STABILITY_PERIOD_DAYS};
+
+const REPO_NAME: &str = "filemap";
+
+/// Well-known path inside the rootfs where the filemap is stored.
+///
+/// Build systems (e.g. BuildStream) write their component–file mapping here at
+/// build time so chunkah can auto-detect it — no CLI flag required.
+pub const FILEMAP_PATH: &str = "usr/lib/chunkah/filemap.json";
+
+/// Per-component entry in the file-map JSON.
+///
+/// ```json
+/// {
+///   "gnome-shell": { "interval": "weekly",  "files": ["/usr/bin/gnome-shell", ...] },
+///   "glibc":       { "interval": "monthly", "files": ["/usr/lib64/libc.so.6", ...] }
+/// }
+/// ```
+#[derive(Debug, Deserialize)]
+pub struct FileMapEntry {
+    /// How often this component typically changes.
+    #[serde(default = "default_interval")]
+    pub interval: Interval,
+    /// Exact absolute paths belonging to this component.
+    pub files: Vec<String>,
+}
+
+fn default_interval() -> Interval {
+    Interval::Monthly
+}
+
+/// Update cadence for stability calculations.
+#[derive(Debug, Deserialize, Clone, Copy, PartialEq, Eq)]
+#[serde(rename_all = "lowercase")]
+pub enum Interval {
+    Daily,
+    Weekly,
+    Monthly,
+}
+
+impl Interval {
+    fn period_days(self) -> f64 {
+        match self {
+            Interval::Daily => 1.0,
+            Interval::Weekly => 7.0,
+            Interval::Monthly => 30.0,
+        }
+    }
+
+    /// Stability score: exponential decay `e^(-T/period)` where T =
+    /// `STABILITY_PERIOD_DAYS`.  This keeps daily < weekly < monthly strictly
+    /// ordered and never collapses to 0.
+    fn stability(self) -> f64 {
+        (-STABILITY_PERIOD_DAYS / self.period_days()).exp()
+    }
+}
+
+/// Per-component metadata derived from file-map entries.
+struct ComponentMeta {
+    name: String,
+    stability: f64,
+}
+
+/// Claims files based on an exact file-path map embedded in the rootfs.
+///
+/// Intended for build systems such as BuildStream that have full file-level
+/// provenance but cannot preserve xattrs through OCI export.  The map is
+/// written to [`FILEMAP_PATH`] at build time and auto-detected here — no CLI
+/// flag required, analogous to how the RPM backend detects the rpmdb.
+///
+/// **File format** — a JSON object keyed by component name:
+///
+/// ```json
+/// {
+///   "gnome-shell": {
+///     "interval": "weekly",
+///     "files": ["/usr/bin/gnome-shell", "/usr/lib/gnome-shell/gnome-shell"]
+///   },
+///   "glibc": {
+///     "interval": "monthly",
+///     "files": ["/usr/lib64/libc.so.6"]
+///   }
+/// }
+/// ```
+pub struct FilemapRepo {
+    components: Vec<ComponentMeta>,
+    path_to_component: HashMap<Utf8PathBuf, ComponentId>,
+}
+
+impl FilemapRepo {
+    /// Detect and load the filemap from `rootfs`.
+    ///
+    /// Returns `Ok(None)` if [`FILEMAP_PATH`] is absent — same convention as
+    /// [`super::rpm::RpmRepo::load`].
+    pub fn load(rootfs: &Dir, files: &FileMap, _default_mtime_clamp: u64) -> Result<Option<Self>> {
+        if !rootfs
+            .try_exists(FILEMAP_PATH)
+            .with_context(|| format!("checking for {FILEMAP_PATH}"))?
+        {
+            return Ok(None);
+        }
+
+        let content = rootfs
+            .read_to_string(FILEMAP_PATH)
+            .with_context(|| format!("reading {FILEMAP_PATH}"))?;
+
+        let repo = Self::load_from_str(&content, files)
+            .with_context(|| format!("parsing {FILEMAP_PATH}"))?;
+
+        tracing::info!(
+            path = FILEMAP_PATH,
+            components = repo.components.len(),
+            paths = repo.path_to_component.len(),
+            "loaded filemap"
+        );
+
+        Ok(Some(repo))
+    }
+
+    /// Parse a filemap from a JSON string.  Used by `load()` and tests.
+    fn load_from_str(content: &str, files: &FileMap) -> Result<Self> {
+        let entries: HashMap<String, FileMapEntry> =
+            serde_json::from_str(content).context("deserializing filemap JSON")?;
+
+        let mut component_index: IndexSet<String> = IndexSet::new();
+        let mut stabilities: Vec<f64> = Vec::new();
+        let mut path_to_component: HashMap<Utf8PathBuf, ComponentId> = HashMap::new();
+
+        for (name, entry) in &entries {
+            let (comp_idx, _) = component_index.insert_full(name.clone());
+            if comp_idx >= stabilities.len() {
+                stabilities.push(entry.interval.stability());
+            }
+            let comp_id = ComponentId(comp_idx);
+
+            for path_str in &entry.files {
+                let path = Utf8PathBuf::from(path_str);
+                if files.contains_key(&path) {
+                    path_to_component.insert(path, comp_id);
+                }
+            }
+        }
+
+        let components: Vec<ComponentMeta> = component_index
+            .into_iter()
+            .zip(stabilities)
+            .map(|(name, stability)| ComponentMeta { name, stability })
+            .collect();
+
+        Ok(Self {
+            components,
+            path_to_component,
+        })
+    }
+}
+
+impl ComponentsRepo for FilemapRepo {
+    fn name(&self) -> &'static str {
+        REPO_NAME
+    }
+
+    /// Priority 5: below xattr (0) but above rpm (10).  BST-generated file maps
+    /// have build-time provenance; treat them as authoritative.
+    fn default_priority(&self) -> usize {
+        5
+    }
+
+    fn strong_claims_for_path(&self, path: &Utf8Path, _file_info: &super::FileInfo) -> Vec<ComponentId> {
+        self.path_to_component
+            .get(path)
+            .copied()
+            .into_iter()
+            .collect()
+    }
+
+    fn component_info(&self, id: ComponentId) -> ComponentInfo<'_> {
+        let meta = &self.components[id.0];
+        ComponentInfo {
+            name: &meta.name,
+            mtime_clamp: 0,
+            stability: meta.stability,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_repo(json: &str) -> FilemapRepo {
+        let files: FileMap = [
+            "/usr/bin/gnome-shell",
+            "/usr/lib/gnome-shell/gnome-shell",
+            "/usr/lib64/libc.so.6",
+            "/usr/share/doc/glibc/README",
+        ]
+        .iter()
+        .map(|p| {
+            (
+                Utf8PathBuf::from(*p),
+                super::super::FileInfo::dummy(super::super::FileType::File),
+            )
+        })
+        .collect();
+        FilemapRepo::load_from_str(json, &files).unwrap()
+    }
+
+    #[test]
+    fn basic_claims() {
+        let repo = make_repo(
+            r#"{
+              "gnome-shell": { "interval": "weekly",  "files": ["/usr/bin/gnome-shell", "/usr/lib/gnome-shell/gnome-shell"] },
+              "glibc":       { "interval": "monthly", "files": ["/usr/lib64/libc.so.6"] }
+            }"#,
+        );
+
+        let shell_id = repo
+            .path_to_component
+            .get(Utf8Path::new("/usr/bin/gnome-shell"))
+            .copied()
+            .unwrap();
+        assert_eq!(repo.components[shell_id.0].name, "gnome-shell");
+
+        let glibc_id = repo
+            .path_to_component
+            .get(Utf8Path::new("/usr/lib64/libc.so.6"))
+            .copied()
+            .unwrap();
+        assert_eq!(repo.components[glibc_id.0].name, "glibc");
+
+        assert!(repo
+            .path_to_component
+            .get(Utf8Path::new("/usr/share/doc/glibc/README"))
+            .is_none());
+    }
+
+    #[test]
+    fn stability_ordering() {
+        let daily = Interval::Daily.stability();
+        let weekly = Interval::Weekly.stability();
+        let monthly = Interval::Monthly.stability();
+        assert!(daily < weekly);
+        assert!(weekly < monthly);
+        assert!(daily > 0.0);
+    }
+
+    #[test]
+    fn default_interval_is_monthly() {
+        let repo = make_repo(r#"{ "myapp": { "files": ["/usr/bin/gnome-shell"] } }"#);
+        let id = repo
+            .path_to_component
+            .get(Utf8Path::new("/usr/bin/gnome-shell"))
+            .copied()
+            .unwrap();
+        assert!(
+            (repo.components[id.0].stability - Interval::Monthly.stability()).abs() < 1e-9
+        );
+    }
+
+    #[test]
+    fn unknown_paths_ignored() {
+        let repo = make_repo(r#"{ "ghost": { "files": ["/does/not/exist"] } }"#);
+        assert!(repo.path_to_component.is_empty());
+    }
+}

--- a/src/components/mod.rs
+++ b/src/components/mod.rs
@@ -1,4 +1,5 @@
 mod bigfiles;
+pub mod filemap;
 mod rpm;
 mod xattr;
 
@@ -126,6 +127,14 @@ impl ComponentsRepos {
             rpm::RpmRepo::load(rootfs, files, default_mtime_clamp).context("loading rpmdb")?
         {
             tracing::info!(repo = "rpm", "loaded repo");
+            repos.push(Box::new(repo));
+        }
+
+        if let Some(repo) =
+            filemap::FilemapRepo::load(rootfs, files, default_mtime_clamp)
+                .context("loading filemap")?
+        {
+            tracing::info!(repo = "filemap", "loaded repo");
             repos.push(Box::new(repo));
         }
 

--- a/tools/gen-filemap/adapters/__init__.py
+++ b/tools/gen-filemap/adapters/__init__.py
@@ -1,0 +1,15 @@
+"""Adapter registry for gen-filemap.
+
+To add a new build-system adapter:
+1. Create ``adapters/<name>.py`` implementing :class:`~base.PackageAdapter`.
+2. Import and register it here.
+"""
+
+from .base import PackageAdapter, ComponentInfo
+from .bst import BstAdapter
+
+ADAPTERS: dict[str, type[PackageAdapter]] = {
+    BstAdapter.NAME: BstAdapter,
+}
+
+__all__ = ["ADAPTERS", "PackageAdapter", "ComponentInfo"]

--- a/tools/gen-filemap/adapters/base.py
+++ b/tools/gen-filemap/adapters/base.py
@@ -1,0 +1,70 @@
+"""Abstract base class for package manager adapters."""
+
+from __future__ import annotations
+
+import abc
+from dataclasses import dataclass, field
+from typing import Iterator
+
+
+@dataclass
+class ComponentInfo:
+    """A single component (package/element) and the files it owns."""
+    name: str
+    """Component name, used as the key in the output filemap."""
+    files: list[str]
+    """Absolute paths of files owned by this component."""
+    interval: str = "monthly"
+    """Expected update cadence: 'daily', 'weekly', or 'monthly'."""
+
+
+class PackageAdapter(abc.ABC):
+    """Interface that every package-manager adapter must implement.
+
+    Adding support for a new package manager means writing a subclass of this
+    class and registering it in ``adapters/__init__.py``.  The subclass must
+    implement :meth:`components`; everything else has a sensible default.
+
+    Example skeleton::
+
+        class MyAdapter(PackageAdapter):
+            NAME = "mypkg"
+            DESCRIPTION = "MyPkg package manager"
+
+            def __init__(self, rootfs: str, **kwargs):
+                self.rootfs = rootfs
+
+            def components(self) -> Iterator[ComponentInfo]:
+                for pkg in query_mypkg(self.rootfs):
+                    yield ComponentInfo(
+                        name=pkg.name,
+                        files=pkg.file_list(),
+                        interval=self.default_interval(pkg),
+                    )
+
+    The adapter is instantiated by ``gen_filemap.py`` with the CLI arguments
+    converted to keyword arguments, so add whatever ``__init__`` parameters you
+    need and document them in ``add_arguments``.
+    """
+
+    #: Short identifier used on the CLI (``--adapter NAME``).
+    NAME: str = ""
+    #: One-line description shown in ``--help``.
+    DESCRIPTION: str = ""
+
+    @abc.abstractmethod
+    def components(self) -> Iterator[ComponentInfo]:
+        """Yield one :class:`ComponentInfo` per component.
+
+        Files that appear in multiple components should be yielded by the last
+        component to claim them (later entries win when the filemap is built).
+        """
+
+    @classmethod
+    def add_arguments(cls, parser) -> None:  # type: ignore[type-arg]
+        """Add adapter-specific arguments to *parser*.
+
+        Override this to expose adapter-specific flags.  Arguments are added
+        to the same parser as the global flags so keep names namespaced (e.g.
+        ``--bst-project`` rather than ``--project``).
+        """

--- a/tools/gen-filemap/adapters/bst.py
+++ b/tools/gen-filemap/adapters/bst.py
@@ -1,0 +1,162 @@
+"""BuildStream adapter for gen-filemap.
+
+Generates a chunkah file-map by querying the local BST artifact cache via
+``bst artifact list-contents``.  Each BST element becomes one component.
+
+Requirements
+------------
+- ``bst`` must be on PATH (or invocable via ``--bst-cmd``).
+- The target element (and its dependencies) must be cached locally.
+- Run from inside the BST project directory, or pass ``--bst-project``.
+
+Usage
+-----
+::
+
+    gen-filemap --adapter bst \\
+        --bst-project ~/dakota \\
+        --bst-target  oci/bluefin.bst \\
+        --output      filemap.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import subprocess
+import sys
+from typing import Iterator
+
+from .base import ComponentInfo, PackageAdapter
+
+
+# Intervals are heuristic — BST elements don't carry update cadence metadata.
+# Adjust these patterns to match your project's naming conventions.
+_INTERVAL_HINTS: list[tuple[str, str]] = [
+    # faster-moving Bluefin/GNOME additions
+    ("bluefin/", "weekly"),
+    ("gnome/gnome-shell", "weekly"),
+    ("gnome/mutter", "weekly"),
+    ("gnome/gdm", "monthly"),
+    # large, slow-moving base layers
+    ("freedesktop-sdk.bst", "monthly"),
+    ("gnome-build-meta.bst", "monthly"),
+]
+_DEFAULT_INTERVAL = "monthly"
+
+
+def _guess_interval(element_name: str) -> str:
+    for prefix, interval in _INTERVAL_HINTS:
+        if prefix in element_name:
+            return interval
+    return _DEFAULT_INTERVAL
+
+
+class BstAdapter(PackageAdapter):
+    NAME = "bst"
+    DESCRIPTION = "BuildStream — queries local artifact cache via `bst artifact list-contents`"
+
+    def __init__(self, bst_project: str, bst_target: str, bst_cmd: str = "bst", **_kwargs):
+        self.project = bst_project
+        self.target = bst_target
+        self.bst_cmd = bst_cmd
+
+    # ------------------------------------------------------------------
+    # PackageAdapter interface
+    # ------------------------------------------------------------------
+
+    def components(self) -> Iterator[ComponentInfo]:
+        elements = self._list_elements()
+        total = len(elements)
+        for i, elem in enumerate(elements, 1):
+            print(f"  [{i}/{total}] {elem}", end="\r", file=sys.stderr)
+            files = self._list_contents(elem)
+            if files:
+                yield ComponentInfo(
+                    name=self._component_name(elem),
+                    files=files,
+                    interval=_guess_interval(elem),
+                )
+        print(file=sys.stderr)  # newline after progress
+
+    @classmethod
+    def add_arguments(cls, parser: argparse.ArgumentParser) -> None:
+        parser.add_argument(
+            "--bst-project",
+            default=".",
+            metavar="DIR",
+            help="Path to the BST project directory (default: current directory)",
+        )
+        parser.add_argument(
+            "--bst-target",
+            required=True,
+            metavar="ELEMENT",
+            help="Top-level BST element whose full dependency tree to map "
+                 "(e.g. oci/bluefin.bst)",
+        )
+        parser.add_argument(
+            "--bst-cmd",
+            default="bst",
+            metavar="CMD",
+            help="BST executable or wrapper (default: bst). "
+                 "Use e.g. 'just bst' if BST runs inside a container.",
+        )
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _bst(self, *args: str) -> str:
+        """Run a bst subcommand and return stdout."""
+        cmd = self.bst_cmd.split() + list(args)
+        result = subprocess.run(
+            cmd,
+            cwd=self.project,
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"`{' '.join(cmd)}` failed:\n{result.stderr.strip()}"
+            )
+        return result.stdout
+
+    def _list_elements(self) -> list[str]:
+        """Return all elements in the dependency tree of the target."""
+        out = self._bst(
+            "show",
+            "--format", "%{name}\n",
+            "--deps", "all",
+            self.target,
+        )
+        return [line.strip() for line in out.splitlines() if line.strip()]
+
+    def _list_contents(self, element: str) -> list[str]:
+        """Return the absolute file paths installed by *element*.
+
+        Returns an empty list if the artifact is not in the local cache.
+        """
+        try:
+            out = self._bst("artifact", "list-contents", "--long", element)
+        except RuntimeError:
+            return []
+
+        files = []
+        for line in out.splitlines():
+            # `bst artifact list-contents --long` format:
+            #   <element>:
+            #       usr/bin/foo   (no leading slash, no type indicator for files)
+            line = line.strip()
+            if not line or line.endswith(":"):
+                continue
+            # Skip directory entries (they end with /)
+            if line.endswith("/"):
+                continue
+            # Strip any leading whitespace / tab characters and ensure abs path
+            path = "/" + line.lstrip()
+            files.append(path)
+        return files
+
+    @staticmethod
+    def _component_name(element: str) -> str:
+        """Convert 'bluefin/gnome-shell.bst' → 'bluefin-gnome-shell'."""
+        return element.replace("/", "-").removesuffix(".bst")

--- a/tools/gen-filemap/gen_filemap.py
+++ b/tools/gen-filemap/gen_filemap.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+"""gen-filemap — generate a chunkah filemap from a build-system artifact database.
+
+The output is a JSON file suitable for placement at
+``usr/lib/chunkah/filemap.json`` inside the OCI rootfs.  chunkah auto-detects
+that path and uses it for rechunking without any extra flags.
+
+Usage
+-----
+::
+
+    gen-filemap --adapter bst \\
+        --bst-project ~/dakota \\
+        --bst-target  oci/bluefin.bst \\
+        --bst-cmd     "just bst" \\
+        --output      filemap.json
+
+    # Or write directly into a checked-out rootfs:
+    gen-filemap --adapter bst ... \\
+        --output /path/to/rootfs/usr/lib/chunkah/filemap.json
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from pathlib import Path
+
+from adapters import ADAPTERS
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="gen-filemap",
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "--adapter",
+        required=True,
+        choices=sorted(ADAPTERS),
+        metavar="ADAPTER",
+        help=f"Build-system adapter to use. Available: {', '.join(sorted(ADAPTERS))}",
+    )
+    parser.add_argument(
+        "--output",
+        "-o",
+        default="-",
+        metavar="FILE",
+        help="Output path (default: stdout). Use '-' for stdout.",
+    )
+    parser.add_argument(
+        "--indent",
+        type=int,
+        default=2,
+        metavar="N",
+        help="JSON indentation level (default: 2; use 0 for compact)",
+    )
+
+    # Let each adapter add its own flags
+    for adapter_cls in ADAPTERS.values():
+        group = parser.add_argument_group(f"{adapter_cls.NAME} adapter options")
+        adapter_cls.add_arguments(group)
+
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+
+    adapter_cls = ADAPTERS[args.adapter]
+    adapter = adapter_cls(**vars(args))
+
+    filemap: dict = {}
+    total_files = 0
+
+    print(f"Generating filemap with adapter '{args.adapter}'...", file=sys.stderr)
+    for component in adapter.components():
+        filemap[component.name] = {
+            "interval": component.interval,
+            "files": sorted(component.files),
+        }
+        total_files += len(component.files)
+
+    print(
+        f"Done: {len(filemap)} components, {total_files} files.",
+        file=sys.stderr,
+    )
+
+    indent = args.indent if args.indent > 0 else None
+    output_json = json.dumps(filemap, indent=indent, ensure_ascii=False)
+
+    if args.output == "-":
+        print(output_json)
+    else:
+        out_path = Path(args.output)
+        out_path.parent.mkdir(parents=True, exist_ok=True)
+        out_path.write_text(output_json + "\n", encoding="utf-8")
+        print(f"Written to {out_path}", file=sys.stderr)
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Closes #110.

Adds a `filemap` backend: auto-detects `usr/lib/chunkah/filemap.json` in the rootfs (no CLI flag), analogous to how the RPM backend finds the rpmdb. Intended for BuildStream-based images where xattrs are stripped on OCI export.

**How it works:** `tools/gen-filemap/gen_filemap.py` queries `bst artifact list-contents` after build and emits an exact file→element map; that JSON is baked into the OCI image; chunkah picks it up automatically.

**Benchmark** — Dakota 7.4 GiB, 197k files, 120 layers:

| | Time | Components | Coverage | Unclaimed |
|---|---|---|---|---|
| baseline | 16.2 s ±0.75 s | 0 | — | 7.4 GiB |
| `--component-map` (PR #111, 127 rules) | 22.1 s ±1.29 s | 54 | 81% | 274 MiB |
| **this PR** (846 BST elements) | **17.5 s ±0.20 s** | **713** | **99%** | **13 MiB** |

Priority 5 (below xattr=0, above rpm=10). 58 tests pass.

Assisted-by: Claude Sonnet 4.6