### PR TITLE
Containerfile: use PQC-enabled rpm-sequoia from CentOS Stream 10

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -18,11 +18,17 @@ RUN --mount=type=cache,rw,id=cargo,target=/root/.cargo \
     --mount=type=cache,rw,id=${CACHE_ID},target=/build/target \
     cargo build --release && cp /build/target/release/chunkah /usr/bin
 
+# XXX: Temporary hack until Fedora learns to read PQC sigs from el10 images.
+FROM quay.io/centos/centos:stream10 AS c10s
+RUN dnf download -y --repo baseos rpm-sequoia --destdir=/rpms
+
 FROM ${BASE} AS rootfs
 ARG DNF_FLAGS
 RUN --mount=type=cache,id=dnf,target=/mnt \
     cp -a /mnt /var/cache/libdnf5 && \
     dnf install ${DNF_FLAGS} openssl zlib && rm -rf /var/cache/*
+COPY --from=c10s /rpms/ /tmp/rpms/
+RUN rpm -Uvh --oldpackage /tmp/rpms/rpm-sequoia-*.rpm && rm -rf /tmp/rpms
 COPY --from=builder /usr/bin/chunkah /usr/bin/chunkah
 # Repeat inline config below for the `--no-chunk` flow. See related XXX below.
 ENTRYPOINT ["/usr/bin/chunkah"]

--- a/tests/e2e/test-ubi10.sh
+++ b/tests/e2e/test-ubi10.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Test splitting a UBI10 image. This exercises the PQC-enabled rpm-sequoia
+# installed from CentOS Stream 10 to verify we can read the rpmdb of EL10
+# images with post-quantum signatures.
+set -xeuo pipefail
+shopt -s inherit_errexit
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+# shellcheck source=SCRIPTDIR/lib.sh
+. "${SCRIPT_DIR}/lib.sh"
+
+SOURCE_IMAGE="registry.access.redhat.com/ubi10/ubi:latest"
+CHUNKED_IMAGE="localhost/ubi10-chunked:test"
+
+cleanup() {
+    cleanup_images "${CHUNKED_IMAGE}"
+}
+trap cleanup EXIT
+
+podman pull "${SOURCE_IMAGE}"
+set +x
+config_str=$(podman inspect "${SOURCE_IMAGE}")
+set -x
+buildah_build \
+    --from "${SOURCE_IMAGE}" --build-arg CHUNKAH="${CHUNKAH_IMG:?}" \
+    --build-arg CHUNKAH_CONFIG_STR="${config_str}" \
+    --build-arg "CHUNKAH_ARGS=-v" \
+    -t "${CHUNKED_IMAGE}" "${REPO_ROOT}/Containerfile.splitter"
+
+# sanity-check it
+podman run --rm "${CHUNKED_IMAGE}" cat /etc/os-release | grep 'Red Hat Enterprise Linux'
+
+# check for expected RPM components signed by PQC
+assert_has_components "${CHUNKED_IMAGE}" "rpm/glibc" "rpm/openssl"
+
+# verify we got exactly 64 layers (the default)
+assert_layer_count "${CHUNKED_IMAGE}" 64
+
+# verify the chunked image is equivalent to the source
+assert_no_diff "${SOURCE_IMAGE}" "${CHUNKED_IMAGE}"


### PR DESCRIPTION
Currently, to split el10 images correctly, one needs to use a chunkah image built from el10 so that rpm can read PQC signatures in the rpmdb (because Fedora's rpm-sequoia doesn't support PQC yet).

We could switch the base image to c10s or UBI10 or provide separate images, but I don't like any of those options. But I do want a good OOTB experience.

So for now just temporarily hack this up by installing rpm-sequoia from c10s on top of the Fedora base since it's ABI-compatible. If this breaks before Fedora gains PQC support, we can re-evaluate the other options.

Assisted-by: Pi (Claude Opus 4.6)