### PR TITLE
README-dev: fix cosign verify example

### DIFF
--- a/README-dev.md
+++ b/README-dev.md
@@ -89,7 +89,7 @@ the signature of an image using cosign v3+:
 ```shell
 cosign verify \
   --certificate-oidc-issuer https://token.actions.githubusercontent.com \
-  --certificate-github-workflow-repository coreos/chunkah \
+  --certificate-identity-regexp 'https://github\.com/coreos/chunkah/' \
   quay.io/coreos/chunkah:latest
 ```
 


### PR DESCRIPTION
I had switch to `--certificate-github-workflow-repository` at the last minute in #119, but hadn't tested it properly. It's only an additional filter in cosign v3 which otherwise still requires `--certificate-identity` or `--certificate-identity-regexp`. That makes it less useful since it's redundant with those so let's just use `--certificate-identity-regexp'.

Assisted-by: Pi (Claude Opus 4.6)