### PR TITLE
ci: add Zizmor workflow and apply recommendations

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,6 +17,8 @@ updates:
     open-pull-requests-limit: 5
     commit-message:
       prefix: "deps"
+    cooldown:
+      default-days: 7
 
   # GitHub Actions
   - package-ecosystem: github-actions
@@ -30,3 +32,5 @@ updates:
           - "*"
     commit-message:
       prefix: "ci"
+    cooldown:
+      default-days: 7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Configure git
         run: git config --global --add safe.directory '*'
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
         # do this first to avoid building implicitly bumping the lockfile
@@ -64,7 +64,7 @@ jobs:
       options: --privileged --cgroupns=host -v /var/lib/containers -v /var/tmp -v /tmp
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       - name: Install tools
         run: dnf install -y just buildah podman skopeo jq diffutils
       - name: Build image
@@ -73,7 +73,7 @@ jobs:
         run: just test ${{ matrix.tests }}
       - name: Upload test results
         if: always()
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: ${{ matrix.name }}
           path: tests/e2e/results/
@@ -93,7 +93,7 @@ jobs:
       id-token: write # Required to get ID token to sign image using Cosign
     steps:
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
       - name: Create and push manifest
         id: push-manifest
         run: |
@@ -130,7 +130,7 @@ jobs:
       - name: Install skopeo
         run: sudo apt-get update && sudo apt-get install -y skopeo
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4.1.1
+        uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
       - name: Push to quay.io
         id: push-quay
         run: |
@@ -155,7 +155,7 @@ jobs:
           cosign sign --yes --recursive \
             quay.io/coreos/chunkah@${{ steps.push-quay.outputs.digest }}
       - name: Cleanup old images
-        uses: actions/delete-package-versions@v5
+        uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:
           package-name: chunkah
           package-type: container

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,8 @@ jobs:
         run: git config --global --add safe.directory '*'
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install markdownlint
         run: npm install -g markdownlint-cli
         # do this first to avoid building implicitly bumping the lockfile
@@ -65,6 +67,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
       - name: Install tools
         run: dnf install -y just buildah podman skopeo jq diffutils
       - name: Build image

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,14 @@ on:
   pull_request:
     branches: [main]
 
+permissions: {}
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
     container: quay.io/fedora/fedora:latest
+    permissions:
+      contents: read
     steps:
       - name: Install tools
         run: dnf install -y cargo clippy rustfmt just ShellCheck nodejs-npm openssl-devel git jq
@@ -54,7 +58,7 @@ jobs:
     name: ${{ matrix.name }}
     permissions:
       contents: read
-      packages: write
+      packages: write # Required to push image to ghcr.io
     container:
       image: quay.io/fedora/fedora:latest
       options: --privileged --cgroupns=host -v /var/lib/containers -v /var/tmp -v /tmp
@@ -85,8 +89,8 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     permissions:
-      packages: write
-      id-token: write
+      packages: write # Required to push image to ghcr.io
+      id-token: write # Required to get ID token to sign image using Cosign
     steps:
       - name: Install cosign
         uses: sigstore/cosign-installer@v4.1.1
@@ -120,8 +124,8 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-24.04
     permissions:
-      packages: write
-      id-token: write
+      packages: write # Required to clean up old images from ghcr.io
+      id-token: write # Required to get ID token to sign image using Cosign
     steps:
       - name: Install skopeo
         run: sudo apt-get update && sudo apt-get install -y skopeo

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ defaults:
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
-    container: quay.io/fedora/fedora:latest
+    container: quay.io/fedora/fedora:latest # zizmor: ignore[unpinned-images]
     permissions:
       contents: read
     steps:
@@ -67,7 +67,7 @@ jobs:
       contents: read
       packages: write # Required to push image to ghcr.io
     container:
-      image: quay.io/fedora/fedora:latest
+      image: quay.io/fedora/fedora:latest # zizmor: ignore[unpinned-images]
       options: --privileged --cgroupns=host -v /var/lib/containers -v /var/tmp -v /tmp
     steps:
       - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,11 @@ on:
 
 permissions: {}
 
+# This makes `-o pipefail` the default behavior for `run:` steps.
+defaults:
+  run:
+    shell: bash
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
@@ -72,9 +77,19 @@ jobs:
       - name: Install tools
         run: dnf install -y just buildah podman skopeo jq diffutils
       - name: Build image
-        run: just buildimg -- ${{ matrix.base && format('--build-arg=BASE={0}', matrix.base) || '' }}
+        env:
+          BASE_IMAGE: ${{ matrix.base || '' }}
+        run: |
+          if [ -n "${BASE_IMAGE}" ]; then
+            just buildimg -- --build-arg=BASE="${BASE_IMAGE}"
+          else
+            just buildimg
+          fi
       - name: Run tests
-        run: just test ${{ matrix.tests }}
+        env:
+          TESTS: ${{ matrix.tests }}
+        run: |
+          just test ${TESTS}
       - name: Upload test results
         if: always()
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -83,10 +98,13 @@ jobs:
           path: tests/e2e/results/
       - name: Push to ghcr.io
         if: github.event_name == 'push' && matrix.push
+        env:
+          ARCH: ${{ matrix.arch }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-          podman push chunkah ghcr.io/${{ github.repository }}:${{ github.sha }}-${{ matrix.arch }}
+          podman login -u "${GITHUB_ACTOR}" -p "${GH_TOKEN}" ghcr.io
+          podman push chunkah "ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_SHA}-${ARCH}"
 
   manifest:
     needs: e2e-tests
@@ -100,28 +118,33 @@ jobs:
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
       - name: Create and push manifest
         id: push-manifest
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -euo pipefail
-          podman login -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} ghcr.io
-          podman manifest create ghcr.io/${{ github.repository }}:${{ github.sha }} \
-            ghcr.io/${{ github.repository }}:${{ github.sha }}-amd64 \
-            ghcr.io/${{ github.repository }}:${{ github.sha }}-arm64
+          podman login -u "${GITHUB_ACTOR}" -p "${GH_TOKEN}" ghcr.io
+          podman manifest create "ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_SHA}" \
+            "ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_SHA}-amd64" \
+            "ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_SHA}-arm64"
           podman manifest push --digestfile=/tmp/manifest-digest \
-            ghcr.io/${{ github.repository }}:${{ github.sha }}
+            "ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_SHA}"
           echo "digest=$(cat /tmp/manifest-digest)" >> "${GITHUB_OUTPUT}"
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
-            podman tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:${TAG}
-            podman manifest push ghcr.io/${{ github.repository }}:${TAG}
           else
-            podman tag ghcr.io/${{ github.repository }}:${{ github.sha }} ghcr.io/${{ github.repository }}:latest
-            podman manifest push ghcr.io/${{ github.repository }}:latest
+            TAG='latest'
           fi
+          podman tag "ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_SHA}" \
+            "ghcr.io/${GITHUB_REPOSITORY}:${TAG}"
+          podman manifest push "ghcr.io/${GITHUB_REPOSITORY}:${TAG}"
       - name: Sign ghcr.io image
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MANIFEST_DIGEST: ${{ steps.push-manifest.outputs.digest }}
         run: |
-          cosign login ghcr.io -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }}
+          cosign login ghcr.io -u "${GITHUB_ACTOR}" -p "${GH_TOKEN}"
           cosign sign --yes --recursive \
-            ghcr.io/${{ github.repository }}@${{ steps.push-manifest.outputs.digest }}
+            "ghcr.io/${GITHUB_REPOSITORY}@${MANIFEST_DIGEST}"
 
   release:
     needs: manifest
@@ -132,32 +155,45 @@ jobs:
       id-token: write # Required to get ID token to sign image using Cosign
     steps:
       - name: Install skopeo
-        run: sudo apt-get update && sudo apt-get install -y skopeo
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y skopeo
+
       - name: Install cosign
         uses: sigstore/cosign-installer@cad07c2e89fa2edd6e2d7bab4c1aa38e53f76003 # v4.1.1
+
       - name: Push to quay.io
         id: push-quay
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          QUAY_AUTH: ${{ secrets.QUAY_AUTH }}
         run: |
           set -euo pipefail
           mkdir -p ~/.docker
-          echo '${{ secrets.QUAY_AUTH }}' > ~/.docker/config.json
+          echo "${QUAY_AUTH}" > ~/.docker/config.json
           if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
             TAG="${GITHUB_REF#refs/tags/}"
             skopeo copy --all --digestfile=/tmp/quay-digest \
-              --src-creds=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
-              docker://ghcr.io/${{ github.repository }}:${{ github.sha }} docker://quay.io/coreos/chunkah:${TAG}
-            skopeo copy --all --src-creds=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
-              docker://ghcr.io/${{ github.repository }}:${{ github.sha }} docker://quay.io/coreos/chunkah:latest
+              --src-creds="${GITHUB_ACTOR}:${GH_TOKEN}" \
+              "docker://ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_SHA}" \
+              "docker://quay.io/coreos/chunkah:${TAG}"
+            skopeo copy --all --src-creds="${GITHUB_ACTOR}:${GH_TOKEN}" \
+              "docker://ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_SHA}" \
+              'docker://quay.io/coreos/chunkah:latest'
           else
             skopeo copy --all --digestfile=/tmp/quay-digest \
-              --src-creds=${{ github.actor }}:${{ secrets.GITHUB_TOKEN }} \
-              docker://ghcr.io/${{ github.repository }}:${{ github.sha }} docker://quay.io/coreos/chunkah:dev
+              --src-creds="${GITHUB_ACTOR}:${GH_TOKEN}" \
+              "docker://ghcr.io/${GITHUB_REPOSITORY}:${GITHUB_SHA}" \
+              'docker://quay.io/coreos/chunkah:dev'
           fi
           echo "digest=$(cat /tmp/quay-digest)" >> "${GITHUB_OUTPUT}"
+
       - name: Sign quay.io image
+        env:
+          QUAY_DIGEST: ${{ steps.push-quay.outputs.digest }}
         run: |
-          cosign sign --yes --recursive \
-            quay.io/coreos/chunkah@${{ steps.push-quay.outputs.digest }}
+          cosign sign --yes --recursive "quay.io/coreos/chunkah@${QUAY_DIGEST}"
+
       - name: Cleanup old images
         uses: actions/delete-package-versions@e5bc658cc4c965c472efe991f8beea3981499c55 # v5.0.0
         with:

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -2,13 +2,14 @@ name: Dependabot
 
 on: pull_request
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   automerge:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # Required to merge PR
+      pull-requests: write # Required to enable auto-merge for PR
     if: github.actor == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       contents: write # Required to merge PR
       pull-requests: write # Required to enable auto-merge for PR
-    if: github.actor == 'dependabot[bot]'
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
     steps:
       - name: Fetch Dependabot metadata
         id: metadata

--- a/.github/workflows/dependabot.yml
+++ b/.github/workflows/dependabot.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v2
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/msrv-bump.yml
+++ b/.github/workflows/msrv-bump.yml
@@ -41,8 +41,10 @@ jobs:
 
       - name: Update Cargo.toml
         if: steps.current.outputs.msrv != steps.rhel9.outputs.version
+        env:
+          RHEL9_RUST_VERSION: ${{ steps.rhel9.outputs.version }}
         run: |
-          sed -i 's/^rust-version = ".*"/rust-version = "${{ steps.rhel9.outputs.version }}"/' Cargo.toml
+          sed --sandbox -i -e "s/^rust-version = \".*\"/rust-version = \"${RHEL9_RUST_VERSION}\"/" Cargo.toml
 
       - name: Create pull request
         if: steps.current.outputs.msrv != steps.rhel9.outputs.version

--- a/.github/workflows/msrv-bump.yml
+++ b/.github/workflows/msrv-bump.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Configure git
         run: git config --global --add safe.directory '*'
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Get current MSRV
         id: current
@@ -44,7 +44,7 @@ jobs:
 
       - name: Create pull request
         if: steps.current.outputs.msrv != steps.rhel9.outputs.version
-        uses: peter-evans/create-pull-request@v7
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           branch: msrv-bump
           title: "Cargo.toml: bump rust-version to ${{ steps.rhel9.outputs.version }}"

--- a/.github/workflows/msrv-bump.yml
+++ b/.github/workflows/msrv-bump.yml
@@ -22,6 +22,8 @@ jobs:
         run: git config --global --add safe.directory '*'
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
 
       - name: Get current MSRV
         id: current

--- a/.github/workflows/msrv-bump.yml
+++ b/.github/workflows/msrv-bump.yml
@@ -6,14 +6,15 @@ on:
     - cron: '0 9 * * 1'
   workflow_dispatch: {}
 
-permissions:
-  contents: write
-  pull-requests: write
+permissions: {}
 
 jobs:
   check-msrv:
     runs-on: ubuntu-latest
     container: registry.access.redhat.com/ubi9/ubi:latest
+    permissions:
+      contents: write # Required to create branch for PR
+      pull-requests: write # Required to create PR
     steps:
       - name: Install tools
         run: dnf install -y git

--- a/.github/workflows/zizmor.yml
+++ b/.github/workflows/zizmor.yml
@@ -1,0 +1,24 @@
+name: Zizmor
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["**"]
+
+permissions: {}
+
+jobs:
+  zizmor:
+    name: Scan GHA workflows
+    runs-on: ubuntu-24.04
+    permissions:
+      security-events: write # Required to upload SARIF files
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run zizmor
+        uses: zizmorcore/zizmor-action@b1d7e1fb5de872772f31590499237e7cce841e8e # v0.5.3


### PR DESCRIPTION
Add workflow for [Zizmor](https://docs.zizmor.sh/), a widely used static analysis tool for GitHub Actions that can identify many common security issues in workflows, and apply its recommendations to existing workflows:

* [Add Dependabot cooldown timer](https://docs.zizmor.sh/audits/#dependabot-cooldown)
* [Drop unnecessary default permissions](https://docs.zizmor.sh/audits/#excessive-permissions) and document reasons for existing permissions
* [Pin action dependencies to commit hashes](https://docs.zizmor.sh/audits/#unpinned-uses)
* [Don't persist `actions/checkout` credentials](https://docs.zizmor.sh/audits/#artipacked)
* [Fix spoofable Dependabot check](https://docs.zizmor.sh/audits/#bot-conditions)
* [Use environment variables in place of template expansion in code contexts](https://docs.zizmor.sh/audits/#template-injection)
* Explicitly ignore Zizmor warning for unpinned uses of Fedora container, as tests are intentionally run against the latest image.