### PR TITLE
chunk-image-series and analyze-layer-reuse improvements

### DIFF
--- a/tools/analyze-layer-reuse.py
+++ b/tools/analyze-layer-reuse.py
@@ -13,6 +13,7 @@ import argparse
 import json
 import subprocess
 import sys
+import textwrap
 from dataclasses import dataclass
 
 
@@ -273,14 +274,22 @@ def format_human_output(images: list[ImageInfo], analyses: list[UpdateAnalysis],
             if show_changed_components and analysis.added_layers:
                 changed = _components_by_size(analysis.added_layers)
                 if changed:
-                    rest = f", ... and {len(changed) - 5} more" if len(changed) > 5 else ""
-                    lines.append(f"      Changed:   {', '.join(changed[:5])}{rest}")
+                    lines.append(textwrap.fill(
+                        ", ".join(changed),
+                        width=80,
+                        initial_indent="      Changed:   ",
+                        subsequent_indent=" " * 17,
+                    ))
 
             if show_unchanged_components and analysis.shared_layers:
                 unchanged = _components_by_size(analysis.shared_layers)
                 if unchanged:
-                    rest = f", ... and {len(unchanged) - 5} more" if len(unchanged) > 5 else ""
-                    lines.append(f"      Unchanged: {', '.join(unchanged[:5])}{rest}")
+                    lines.append(textwrap.fill(
+                        ", ".join(unchanged),
+                        width=80,
+                        initial_indent="      Unchanged: ",
+                        subsequent_indent=" " * 17,
+                    ))
 
             lines.append("")
 

--- a/tools/chunk-image-series.py
+++ b/tools/chunk-image-series.py
@@ -263,12 +263,25 @@ def get_sorted_tags(args: argparse.Namespace) -> list[str]:
 def _list_tags(repo: str, pattern: str, local: bool = False) -> list[str]:
     """List tags matching glob pattern from registry or containers-storage."""
     if local:
+        # Podman images --filter reference={repo} can output entries
+        # that are unrelated to {repo} so we need to also print {{.Repository}}
+        # and do some filtering of our own here. Apparently this is intended
+        # behavior so we'll have to keep this "workaround" for now:
+        # https://github.com/containers/podman/issues/28643
         output = run_output(
-            "podman", "images", "--format", "{{.Tag}}",
+            "podman", "images", "--format", "{{.Repository}} {{.Tag}}",
             "--noheading", "--filter", f"reference={repo}",
         )
-        all_tags = [t.strip() for t in output.strip().split("\n")
-                    if t.strip() and t.strip() != "<none>"]
+        all_tags = []
+        for line in output.splitlines():
+            parts = line.strip().split(" ", 1)
+            if len(parts) == 2:
+                img_repo, tag = parts
+                # podman's reference filter can match images that share the
+                # same image ID but have a different repository name; filter
+                # those out
+                if tag != "<none>" and img_repo == repo:
+                    all_tags.append(tag)
     else:
         output = run_output("skopeo", "list-tags", f"docker://{repo}")
         data = json.loads(output)

--- a/tools/chunk-image-series.py
+++ b/tools/chunk-image-series.py
@@ -362,7 +362,7 @@ def chunk_image(source_ref: str, chunkah_image: str, original_tag: str,
 
 def load_chunked_image(ociarchive: str):
     """Load OCI archive into containers-storage."""
-    run("podman", "load", "-i", ociarchive)
+    run("podman", "load", "--quiet", "-i", ociarchive)
 
 
 def cleanup_temp_images(refs: list[str]):


### PR DESCRIPTION
```
commit ede16a276c37fc461e4140690251abb7cf47a03e
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon May 4 20:14:03 2026 +0000

    tools/analyze-layer-reuse: show all components with text wrapping
    
    Instead of truncating the changed/unchanged component lists to 5
    entries, show the full list using textwrap.fill() to wrap at 80
    columns with proper indentation.
    
    Assisted-By: <anthropic/claude-opus-4.6>

commit c6741064829d6504e0a76f11347680eada92881a
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon May 4 16:07:11 2026 -0400

    tools/chunk-image-series: filter results of images query
    
    This is needed to workaround the current podman bug that will
    output more matches than we think it should:
    https://github.com/containers/podman/issues/28643
    
    Assisted-By: <anthropic/claude-opus-4.6>

commit 11895c9922731354091c830ea99f8160d430f744
Author: Dusty Mabe <dusty@dustymabe.com>
Date:   Mon May 4 14:37:12 2026 -0400

    tools/chunk-image-series: quiet podman load
    
    Will prevent a ton of output to the terminal on every run.

```