### PR TITLE
fix: use all changelog timestamps to estimate package age

### DIFF
--- a/src/utils.rs
+++ b/src/utils.rs
@@ -120,15 +120,18 @@ pub fn calculate_stability(changelog_times: &[u64], buildtime: u64, now: u64) ->
         return 0.99;
     }
 
-    // Find the oldest timestamp in the window
-    let oldest = changelog_times
-        .iter()
-        .copied()
-        .filter(|&t| t >= lookback_start)
-        .min()
-        .unwrap_or(buildtime);
+    // Find the oldest timestamp for the package
+    let oldest = changelog_times.iter().copied().min().unwrap_or(buildtime);
 
-    let span_days = (now.saturating_sub(oldest)) as f64 / SECS_PER_DAY as f64;
+    let span_days = if oldest >= lookback_start {
+        // If the package's changelog entries are all within the lookback period, we assume the
+        // earliest changelog entry indicates the age of the package.
+        (now.saturating_sub(oldest)) as f64 / SECS_PER_DAY as f64
+    } else {
+        // If the package has timestamps older than the start of the lookback period, then we're
+        // counting updates over the full lookback period.
+        STABILITY_LOOKBACK_DAYS as f64
+    };
 
     if span_days < 1.0 {
         // Very recent package, assume unstable


### PR DESCRIPTION
In the stability calculation, `span_days` should cover the full lookback period if the oldest timestamp is earlier than the beginning of the lookback period. For example, if a package was only updated two years ago and again one month ago, the package is over a year old, so we're looking at one update in the past *year*, not just one update in the past *month* (as we would for a package with no changelog entries earlier than a month ago).

The previous calculation underestimated stability of packages that had no updates for a long time, followed by a recent update.

Also optimize stability computation by avoiding unnecessary allocations.