### PR TITLE
README: mention ALPM/pacman support

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,8 @@ perform this content-based layer splitting.
 
 ## Highlights
 
-- **Content agnostic** — Compatible with RPM-based images, but not only. Other
-  package ecosystems can be supported, as well as fully custom content.
+- **Content agnostic** — Compatible with RPM and pacman (ALPM) based images.
+  Other package ecosystems can be supported, as well as fully custom content.
 - **Container-native** — Best used as a container image, either as part of a
   multi-staged build, or standalone.
 - **Zero diff** — Apart from modification time, content is never modified.
@@ -215,9 +215,9 @@ all files from an RPM belong to the same component. Layers are created based on
 found components.
 
 A component repo is a source of data from which components can be created. For
-example, the rpmdb is a component repo (one can imagine similar component repos
-for other distros). There is also an xattr-based component repo (see the section
-"Customizing the layers" below). Multiple component repos can be active at once.
+example, the rpmdb and the ALPM local database are component repos. There is
+also an xattr-based component repo (see the section "Customizing the layers"
+below). Multiple component repos can be active at once.
 
 ### Customizing the layers
 

--- a/src/components/alpm.rs
+++ b/src/components/alpm.rs
@@ -101,13 +101,13 @@ impl AlpmComponentsRepo {
             let basename = local_db_entry.desc.base().with_context(|| {
                 format!(
                     "parsing base from desc file of alpm db entry {}",
-                    &local_db_entry.source
+                    local_db_entry.source
                 )
             })?;
             let builddate = local_db_entry.desc.builddate().with_context(|| {
                 format!(
                     "parsing builddate from desc file of alpm db entry {}",
-                    &local_db_entry.source
+                    local_db_entry.source
                 )
             })?;
             let stability = calculate_stability(&[], builddate, now);
@@ -142,7 +142,7 @@ impl AlpmComponentsRepo {
             .with_context(|| {
                 format!(
                     "adding package {} to map from paths to alpm components",
-                    &local_db_entry.source
+                    local_db_entry.source
                 )
             })?;
             package_count += 1;
@@ -403,7 +403,7 @@ impl LocalAlpmDbIterator {
             let local_db_entry_file_type = local_db_entry.file_type().with_context(|| {
                 format!(
                     "determining file type of database entry {}",
-                    &local_db_entry_name
+                    local_db_entry_name
                 )
             })?;
 
@@ -416,7 +416,7 @@ impl LocalAlpmDbIterator {
                     .with_context(|| {
                         format!(
                             "getting metadata for database entry {}",
-                            &local_db_entry_name
+                            local_db_entry_name
                         )
                     })?
                     .is_dir()
@@ -430,7 +430,7 @@ impl LocalAlpmDbIterator {
             let package_dir = local_db_entry.open_dir().with_context(|| {
                 format!(
                     "opening dir for alpm database entry {}",
-                    &local_db_entry_name
+                    local_db_entry_name
                 )
             })?;
             return Self::package_info_from_dir(&package_dir, local_db_entry_name)


### PR DESCRIPTION
Update the Highlights and Understanding components sections to reflect that pacman (ALPM) is now a supported component repo alongside RPM.

Assisted-by: Pi (Claude Opus 4.6)